### PR TITLE
Group xunit packages in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: monthly
     target-branch: main
+    groups:
+      xunit:
+        patterns:
+          - "xunit*"
+          - "Xunit*"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Dependabot has been opening xunit-related bumps one package at a time, which caused PR #4 to fail CI: bumping just `xunit.console` to 2.9.3 left `xunit` and `xunit.runner.visualstudio` on their old 2.4.x versions, and the mismatched abstractions blew up the VSTest runner at startup (`LogRaw` missing on `VisualStudioRunnerLogger`).

Grouping them forces dependabot to bump the whole xunit family in a single PR so versions stay in sync.

After this merges, PR #4 can be closed and dependabot will reopen a combined bump on the next run.