### PR TITLE
[Vulkan] Fix VdToVkPixelFormat mapping for 2-component float formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ First release of NeoVeldrid. Drop-in replacement for [Veldrid](https://github.co
 - D3D11 mipmap sampling bug (caused by a struct layout issue in the old Vortice bindings)
 - Vulkan debug callback crash (threw a managed exception from an unmanaged callback)
 - Shaderc compiler recreated on every shader compilation call (now cached)
+- [Vulkan] `PixelFormat.R16_G16_Float` and `PixelFormat.R32_G32_Float` working incorrectly
 
 [Unreleased]: https://github.com/jhm-ciberman/neo-veldrid/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/jhm-ciberman/neo-veldrid/releases/tag/v1.0.0

--- a/src/NeoVeldrid/Vk/VkFormats.VdToVkPixelFormat.cs
+++ b/src/NeoVeldrid/Vk/VkFormats.VdToVkPixelFormat.cs
@@ -56,14 +56,14 @@ namespace NeoVeldrid.Vk
                 case PixelFormat.R16_G16_SInt:
                     return Format.R16G16Sint;
                 case PixelFormat.R16_G16_Float:
-                    return Format.R16G16B16A16Sfloat;
+                    return Format.R16G16Sfloat;
 
                 case PixelFormat.R32_G32_UInt:
                     return Format.R32G32Uint;
                 case PixelFormat.R32_G32_SInt:
                     return Format.R32G32Sint;
                 case PixelFormat.R32_G32_Float:
-                    return Format.R32G32B32A32Sfloat;
+                    return Format.R32G32Sfloat;
 
                 case PixelFormat.R8_G8_B8_A8_UNorm:
                     return Format.R8G8B8A8Unorm;

--- a/tests/NeoVeldrid.Tests/TextureTests.RegressionTests.cs
+++ b/tests/NeoVeldrid.Tests/TextureTests.RegressionTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace NeoVeldrid.Tests
+{
+    // Regression tests for specific bugs that have been fixed in NeoVeldrid. Each test in this
+    // file exists to prevent a particular past bug from coming back; they are not part of the
+    // general behavioral coverage in TextureTests.cs and should not be relied on as
+    // documentation of the public contract. The test name and a comment above each test should
+    // describe the bug it guards against.
+    //
+    // This is a partial of TextureTestBase<T>, so any test added here is automatically picked
+    // up by every per-backend concrete subclass declared at the bottom of TextureTests.cs
+    // (VulkanTextureTests, D3D11TextureTests, OpenGLTextureTests, OpenGLESTextureTests).
+    public abstract partial class TextureTestBase<T> where T : GraphicsDeviceCreator
+    {
+        // Regression test for a Vulkan backend bug where R16_G16_Float and R32_G32_Float were
+        // mapped to their 4-component VK_FORMAT_..._SFLOAT counterparts, doubling the per-pixel
+        // byte size of every texture in those formats. Pure upload-then-readback round-trips
+        // could hide the bug because the wrong stride was applied symmetrically on both copies.
+        // Clearing the render target exposes it: the clear color carries B and A components
+        // that should be discarded for a 2-component target, so any leakage of B/A into the
+        // readback proves the underlying texture has the wrong number of components.
+        [Fact]
+        public void ClearColorTarget_R32_G32_Float_OnlyWritesTwoComponents()
+        {
+            const uint width = 4;
+            const uint height = 1;
+
+            Texture target = RF.CreateTexture(TextureDescription.Texture2D(
+                width, height, 1, 1, PixelFormat.R32_G32_Float, TextureUsage.RenderTarget));
+            Framebuffer fb = RF.CreateFramebuffer(new FramebufferDescription(null, target));
+
+            CommandList cl = RF.CreateCommandList();
+            cl.Begin();
+            cl.SetFramebuffer(fb);
+            // 999f and 7777f are deliberately distinctive sentinels for the B and A channels.
+            // The target is R32_G32_Float, so by the contract those two values must be ignored
+            // and every pixel must read back as exactly (3, 5). The sentinels ensure that any
+            // accidental leakage of B/A into the readback is loud and unambiguous.
+            cl.ClearColorTarget(0, new RgbaFloat(3f, 5f, 999f, 7777f));
+            cl.End();
+            GD.SubmitCommands(cl);
+            GD.WaitForIdle();
+
+            Texture staging = RF.CreateTexture(TextureDescription.Texture2D(
+                width, height, 1, 1, PixelFormat.R32_G32_Float, TextureUsage.Staging));
+            cl.Begin();
+            cl.CopyTexture(target, 0, 0, 0, 0, 0, staging, 0, 0, 0, 0, 0, width, height, 1, 1);
+            cl.End();
+            GD.SubmitCommands(cl);
+            GD.WaitForIdle();
+
+            MappedResourceView<Vector2> view = GD.Map<Vector2>(staging, MapMode.Read);
+            try
+            {
+                for (int y = 0; y < height; y++)
+                {
+                    for (int x = 0; x < width; x++)
+                    {
+                        Assert.Equal(new Vector2(3f, 5f), view[x, y]);
+                    }
+                }
+            }
+            finally
+            {
+                GD.Unmap(staging);
+            }
+
+            cl.Dispose();
+            fb.Dispose();
+            staging.Dispose();
+            target.Dispose();
+        }
+
+        [Fact]
+        public void ClearColorTarget_R16_G16_Float_OnlyWritesTwoComponents()
+        {
+            const uint width = 4;
+            const uint height = 1;
+
+            Texture target = RF.CreateTexture(TextureDescription.Texture2D(
+                width, height, 1, 1, PixelFormat.R16_G16_Float, TextureUsage.RenderTarget));
+            Framebuffer fb = RF.CreateFramebuffer(new FramebufferDescription(null, target));
+
+            CommandList cl = RF.CreateCommandList();
+            cl.Begin();
+            cl.SetFramebuffer(fb);
+            // 999f and 7777f are deliberately distinctive sentinels for the B and A channels:
+            // the target is R16_G16_Float, so by the contract those two values must be ignored
+            // and every pixel must read back as exactly (1, 2). All four values are exactly
+            // representable in IEEE-754 binary16, so the float32 -> float16 narrowing the clear
+            // path performs is lossless and would faithfully preserve the sentinels if a bug
+            // ever let them leak into the readback.
+            cl.ClearColorTarget(0, new RgbaFloat(1f, 2f, 999f, 7777f));
+            cl.End();
+            GD.SubmitCommands(cl);
+            GD.WaitForIdle();
+
+            Texture staging = RF.CreateTexture(TextureDescription.Texture2D(
+                width, height, 1, 1, PixelFormat.R16_G16_Float, TextureUsage.Staging));
+            cl.Begin();
+            cl.CopyTexture(target, 0, 0, 0, 0, 0, staging, 0, 0, 0, 0, 0, width, height, 1, 1);
+            cl.End();
+            GD.SubmitCommands(cl);
+            GD.WaitForIdle();
+
+            MappedResourceView<HalfVector2> view = GD.Map<HalfVector2>(staging, MapMode.Read);
+            try
+            {
+                for (int y = 0; y < height; y++)
+                {
+                    for (int x = 0; x < width; x++)
+                    {
+                        Assert.Equal((Half)1f, view[x, y].X);
+                        Assert.Equal((Half)2f, view[x, y].Y);
+                    }
+                }
+            }
+            finally
+            {
+                GD.Unmap(staging);
+            }
+
+            cl.Dispose();
+            fb.Dispose();
+            staging.Dispose();
+            target.Dispose();
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 2)]
+        private struct HalfVector2
+        {
+            public Half X;
+            public Half Y;
+        }
+    }
+}

--- a/tests/NeoVeldrid.Tests/TextureTests.cs
+++ b/tests/NeoVeldrid.Tests/TextureTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace NeoVeldrid.Tests
 {
-    public abstract class TextureTestBase<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
+    public abstract partial class TextureTestBase<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
     {
         [Fact]
         public void Map_Succeeds()


### PR DESCRIPTION
There's a long-standing copy-paste bug in `VdToVkPixelFormat` (faithfully ported from upstream Veldrid): the two 2-component float formats map to their 4-component Vulkan counterparts.

```csharp
case PixelFormat.R16_G16_Float:
    return Format.R16G16B16A16Sfloat;   // should be R16G16Sfloat
case PixelFormat.R32_G32_Float:
    return Format.R32G32B32A32Sfloat;   // should be R32G32Sfloat
```

Every other R16_G16 / R32_G32 variant (UInt, SInt, UNorm, SNorm) maps correctly, only the float cases were wrong. The result is that any `R16_G16_Float` or `R32_G32_Float` texture is allocated in VRAM with double the per-pixel byte size, and `vkCmdCopyImageToBuffer` into a host-visible staging buffer overruns the destination (caught as a `VUID-vkCmdCopyImageToBuffer-pRegions-00183` validation error in debug builds).

The interesting wrinkle while writing the regression test: a pure upload-then-readback round trip can hide the bug entirely, because the wrong row stride is applied symmetrically on both the upload copy and the readback copy and the user-visible bytes happen to round-trip back through the same misinterpretation. The bug only becomes observable when the texture is written to from a non-buffer source (a clear, a render pass, shader output) because those carry data the user did not put through the symmetric mangling.

So the regression test in `TextureTests.RegressionTests.cs` clears an `R*_G*_Float` render target with sentinel values in the B and A channels (`999f`, `7777f`), then reads the texture back via `CopyTexture` + `Map` and asserts that only the R and G channels survived. Any leakage of the sentinel B/A values into the readback proves the underlying texture has the wrong number of components. Runs on all four backends - Vulkan catches the bug, the others verify the contract is honored consistently.

The new tests live in a partial of `TextureTestBase<T>` in a separate file so the regression suite is visually distinct from the general behavioral coverage. They pick up the existing per-backend concrete subclasses for free.