### PR TITLE
[Vulkan] Fix convenience overload dropping SwapchainSrgbFormat

### DIFF
--- a/src/NeoVeldrid.StartupUtilities/NeoVeldridStartup.cs
+++ b/src/NeoVeldrid.StartupUtilities/NeoVeldridStartup.cs
@@ -200,7 +200,7 @@ namespace NeoVeldrid.StartupUtilities
 
 #if !EXCLUDE_VULKAN_BACKEND
         public static GraphicsDevice CreateVulkanGraphicsDevice(GraphicsDeviceOptions options, Sdl2Window window)
-            => CreateVulkanGraphicsDevice(options, window, false);
+            => CreateVulkanGraphicsDevice(options, window, options.SwapchainSrgbFormat);
         public static GraphicsDevice CreateVulkanGraphicsDevice(
             GraphicsDeviceOptions options,
             Sdl2Window window,

--- a/tests/NeoVeldrid.Tests/SwapchainTests.RegressionTests.cs
+++ b/tests/NeoVeldrid.Tests/SwapchainTests.RegressionTests.cs
@@ -1,0 +1,86 @@
+using NeoVeldrid.Sdl2;
+using NeoVeldrid.StartupUtilities;
+using Xunit;
+
+namespace NeoVeldrid.Tests
+{
+    // Regression tests for specific swapchain-related bugs that have been fixed in NeoVeldrid.
+    // Unlike the generic SwapchainTests / MainSwapchainTests infrastructure in SwapchainTests.cs,
+    // each test here creates its own device with bug-specific options rather than inheriting a
+    // pre-built device from a shared fixture, because the bugs under test are in the device
+    // creation path itself.
+    public class SwapchainRegressionTests
+    {
+        // Regression test for a bug where the 2-argument convenience overload of
+        // NeoVeldridStartup.CreateVulkanGraphicsDevice hardcoded `colorSrgb = false` instead of
+        // passing `options.SwapchainSrgbFormat` through to the 3-argument overload. Because
+        // NeoVeldridStartup.CreateGraphicsDevice (the default dispatch from
+        // CreateWindowAndGraphicsDevice) routes to the 2-argument overload, every application
+        // using the default code path to create a Vulkan device got a non-sRGB swapchain even
+        // when they explicitly set GraphicsDeviceOptions.SwapchainSrgbFormat = true.
+        //
+        // D3D11 (and OpenGL, though not tested here) already honored SwapchainSrgbFormat, so the
+        // fix restores parity with the contract the other backends established.
+#if TEST_VULKAN
+        [Fact]
+        [Trait("Backend", "Vulkan")]
+        public void CreateWindowAndGraphicsDevice_Vulkan_HonorsSwapchainSrgbFormat()
+        {
+            AssertMainSwapchainIsSrgb(GraphicsBackend.Vulkan);
+        }
+#endif
+
+#if TEST_D3D11
+        [Fact]
+        [Trait("Backend", "D3D11")]
+        public void CreateWindowAndGraphicsDevice_D3D11_HonorsSwapchainSrgbFormat()
+        {
+            AssertMainSwapchainIsSrgb(GraphicsBackend.Direct3D11);
+        }
+#endif
+
+#if TEST_OPENGL
+        [Fact]
+        [Trait("Backend", "OpenGL")]
+        public void CreateWindowAndGraphicsDevice_OpenGL_HonorsSwapchainSrgbFormat()
+        {
+            AssertMainSwapchainIsSrgb(GraphicsBackend.OpenGL);
+        }
+#endif
+
+        private static void AssertMainSwapchainIsSrgb(GraphicsBackend backend)
+        {
+            WindowCreateInfo wci = new WindowCreateInfo
+            {
+                WindowWidth = 200,
+                WindowHeight = 200,
+                WindowInitialState = WindowState.Hidden,
+            };
+
+            GraphicsDeviceOptions options = new GraphicsDeviceOptions(
+                debug: true,
+                swapchainDepthFormat: PixelFormat.R16_UNorm,
+                syncToVerticalBlank: false,
+                resourceBindingModel: ResourceBindingModel.Default,
+                preferDepthRangeZeroToOne: false,
+                preferStandardClipSpaceYDirection: false,
+                swapchainSrgbFormat: true);
+
+            Sdl2Window window = null;
+            GraphicsDevice gd = null;
+            try
+            {
+                NeoVeldridStartup.CreateWindowAndGraphicsDevice(wci, options, backend, out window, out gd);
+
+                PixelFormat colorFormat = gd.MainSwapchain.Framebuffer.ColorTargets[0].Target.Format;
+
+                Assert.Equal(PixelFormat.B8_G8_R8_A8_UNorm_SRgb, colorFormat);
+            }
+            finally
+            {
+                gd?.Dispose();
+                window?.Close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
`NeoVeldridStartup.CreateVulkanGraphicsDevice` has two overloads: a 3-argument one that takes `(options, window, colorSrgb)` and a 2-argument convenience overload at `NeoVeldridStartup.cs:202` that's supposed to forward `options.SwapchainSrgbFormat` through.

It doesn't. It hardcodes `false`:

```csharp
public static GraphicsDevice CreateVulkanGraphicsDevice(GraphicsDeviceOptions options, Sdl2Window window)
    => CreateVulkanGraphicsDevice(options, window, false);   // <-- wrong
```

The 2-argument overload is the one `CreateGraphicsDevice` dispatches to, which is the one `CreateWindowAndGraphicsDevice` dispatches to, which is the one the vast majority of apps and samples use. So on Vulkan, `GraphicsDeviceOptions.SwapchainSrgbFormat = true` was silently discarded for anyone using the default device-creation path. D3D11 and OpenGL both honored the option correctly (each through a different internal mechanism), so this shipped as a Vulkan-specific regression against the contract the other backends had already established.

The fix is one character longer than the bug, so to speak:

```csharp
=> CreateVulkanGraphicsDevice(options, window, options.SwapchainSrgbFormat);
```

The regression test in `SwapchainTests.RegressionTests.cs` creates a hidden-window device through the same `CreateWindowAndGraphicsDevice` path that real apps use, with `SwapchainSrgbFormat = true`, and asserts the main swapchain color target comes back as `B8_G8_R8_A8_UNorm_SRgb`. It runs on Vulkan (catches the bug), D3D11 (control group, has always worked), and OpenGL (control group, has always worked through the `GL_FRAMEBUFFER_SRGB_CAPABLE` attribute + a runtime GPU probe). OpenGL ES is deliberately excluded: its sRGB path short-circuits when `EXT_sRGBWriteControl` is missing, and that extension is a coin flip across ANGLE builds, which would make the test flaky in CI through no fault of NeoVeldrid.

One design note: the assertion is strict equality against `B8_G8_R8_A8_UNorm_SRgb`, not a loose "any sRGB format" check. Every backend we support picks BGRA for the swapchain color format on desktop (inherited from the historical Windows GDI / DXGI / Core Animation convention that window backing stores are BGRA in memory), and if that ever changes on any backend we want to know about it as a meaningful behavior change rather than silently absorb it.