### PR TITLE
[Vulkan] Fix descriptor pool leak for dynamic buffer counts

### DIFF
--- a/src/NeoVeldrid/Vk/VkDescriptorPoolManager.cs
+++ b/src/NeoVeldrid/Vk/VkDescriptorPoolManager.cs
@@ -170,17 +170,20 @@ namespace NeoVeldrid.Vk
                 }
             }
 
-            internal unsafe void Free(VkGraphicsDevice gd, DescriptorAllocationToken token, DescriptorResourceCounts counts)
+            internal void Free(VkGraphicsDevice gd, DescriptorAllocationToken token, DescriptorResourceCounts counts)
             {
                 DescriptorSet set = token.Set;
                 gd.Vk.FreeDescriptorSets(gd.Device, Pool, 1, in set);
 
+                // Every counter decremented in Allocate must be incremented here; the two methods
+                // must stay symmetric or the pool slowly leaks descriptor headroom under churn.
                 RemainingSets += 1;
-
                 UniformBufferCount += counts.UniformBufferCount;
+                UniformBufferDynamicCount += counts.UniformBufferDynamicCount;
                 SampledImageCount += counts.SampledImageCount;
                 SamplerCount += counts.SamplerCount;
                 StorageBufferCount += counts.StorageBufferCount;
+                StorageBufferDynamicCount += counts.StorageBufferDynamicCount;
                 StorageImageCount += counts.StorageImageCount;
             }
         }


### PR DESCRIPTION
Long-standing upstream Veldrid bug faithfully ported into NeoVeldrid. `VkDescriptorPoolManager.PoolInfo.Allocate` decrements 7 shadow counters but `Free` was only restoring 5 of them, forgetting the two `*DynamicCount` fields. Apps churning through resource sets with `DynamicBinding` slowly drained those counters and forced the manager to spin up redundant backing pools, wasting VRAM over time.

Added a comment above `Free` stating the symmetry invariant so a future edit that adds a new descriptor category has a reminder to update both methods.