### PR TITLE
[SDL2] Remove SetMousePosition mouselook emulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 First release of NeoVeldrid. A maintained, drop-in replacement for [Veldrid](https://github.com/mellinoe/veldrid) with every native binding replaced by [Silk.NET](https://github.com/dotnet/Silk.NET). If you have a Veldrid project today, migrating is roughly a 5 minute find-and-replace. See the [Migration Guide](docs/articles/prologue/migration.md) for the exact steps.
 
+### Breaking
+
+- `Sdl2Window.SetMousePosition` no longer supports per-frame warp-cursor-back mouselook. Code using that pattern must switch to `CursorRelativeMode` + `MouseDelta`. See the [Migration Guide](docs/articles/prologue/migration.md#mouselook-with-setmouseposition).
+
 ### Changed
 
 - Vulkan backend now binds through `Silk.NET.Vulkan` 2.23.0 (was `Vk` 1.0.25).
@@ -42,6 +46,8 @@ First release of NeoVeldrid. A maintained, drop-in replacement for [Veldrid](htt
 - [Vulkan] `GraphicsDeviceOptions.SwapchainSrgbFormat` being silently ignored by `CreateWindowAndGraphicsDevice`, so Vulkan swapchains always came back in the linear-UNorm format regardless of what the user requested.
 - [Vulkan] Fixes memory leak with `VkDescriptorPoolManager` related to unfreed dynamic buffers.
 - [Vulkan] Fixes `CreateLogicalDevice` ignoring the present queue family on GPUs where it differs from the graphics family.
+- [SDL2] Scroll-to-zoom now respects sub-detent deltas from precision touchpads and high-end mice. Slow scrolls no longer round to zero.
+- [SDL2] Cursor position no longer desyncs when the window regains focus or the pointer re-enters the window on Windows. Modern SDL2 emits zero-delta motion events in those cases, and the previous filter discarded them too aggressively.
 
 [Unreleased]: https://github.com/jhm-ciberman/neo-veldrid/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/jhm-ciberman/neo-veldrid/releases/tag/v1.0.0

--- a/docs/articles/prologue/migration.md
+++ b/docs/articles/prologue/migration.md
@@ -111,3 +111,47 @@ The `NeoVeldrid.ImGui` package now uses ImGui.NET 1.91.6.1 (up from 1.90.1.1). T
 **Likelihood Of Impact: Low**
 
 The `NeoVeldrid.ImageSharp` package now uses SixLabors.ImageSharp 3.x (up from 1.x). The NeoVeldrid.ImageSharp API itself is unchanged, but if your own code also calls ImageSharp directly, you may need to update it. See the [ImageSharp 3.0 announcement](https://sixlabors.com/posts/announcing-imagesharp-300/) for breaking changes.
+
+### Mouselook With `SetMousePosition`
+
+**Likelihood Of Impact: Medium**
+
+`Sdl2Window.SetMousePosition` is now a plain wrapper around `SDL_WarpMouseInWindow`. Code that captures the cursor and warps it back to a fixed anchor each frame to read the user's offset is no longer reliable on Windows. Patterns affected include:
+
+- First-person camera mouselook.
+- Orbit and pan cameras with mouse drag.
+- Middle-button autoscroll.
+- Drag-to-rotate or drag-to-pan viewport interactions.
+
+Switch to relative mouse mode and read per-frame deltas via `MouseDelta`.
+
+In Veldrid:
+
+```csharp
+// Per-frame, read the cursor's offset from the anchor and reset it back to the anchor
+InputSnapshot snapshot = _window.PumpEvents();
+Vector2 delta = _anchor - snapshot.MousePosition;
+_window.SetMousePosition(_anchor);
+yaw += delta.X * sensitivity;
+pitch += delta.Y * sensitivity;
+```
+
+In NeoVeldrid:
+
+```csharp
+// When capture begins, enable relative mode to lock the cursor to the window and read deltas directly
+_window.CursorRelativeMode = true;
+
+// Per-frame
+InputSnapshot snapshot = _window.PumpEvents();
+Vector2 delta = _window.MouseDelta;
+yaw -= delta.X * sensitivity; // Note the inverted sign
+pitch -= delta.Y * sensitivity;
+
+// When capture ends, disable relative mode to restore the cursor's original position
+_window.CursorRelativeMode = false;
+```
+
+While `CursorRelativeMode` is active, the cursor is hidden and confined to the window; disabling it restores the original position.
+
+Note the `+=` becomes `-=`. `_anchor - snapshot.MousePosition` measures how far the cursor has drifted from the anchor; `MouseDelta` measures how far it has moved since the previous frame. Same magnitude, opposite sign.

--- a/samples/NeoDemo/Camera.cs
+++ b/samples/NeoDemo/Camera.cs
@@ -23,7 +23,6 @@ namespace NeoVeldrid.NeoDemo
         private float _yaw;
         private float _pitch;
 
-        private Vector2 _mousePressedPos;
         private bool _mousePressed = false;
         private GraphicsDevice _gd;
         private bool _useReverseDepth;
@@ -118,17 +117,16 @@ namespace NeoVeldrid.NeoDemo
                 if (!_mousePressed)
                 {
                     _mousePressed = true;
-                    _mousePressedPos = InputTracker.MousePosition;
                     _window.CursorVisible = false;
+                    _window.CursorRelativeMode = true;
                 }
-                Vector2 mouseDelta = _mousePressedPos - InputTracker.MousePosition;
-                _window.SetMousePosition((int)_mousePressedPos.X, (int)_mousePressedPos.Y);
-                Yaw += mouseDelta.X * 0.002f;
-                Pitch += mouseDelta.Y * 0.002f;
+                Vector2 mouseDelta = _window.MouseDelta;
+                Yaw -= mouseDelta.X * 0.002f;
+                Pitch -= mouseDelta.Y * 0.002f;
             }
-            else if(_mousePressed)
+            else if (_mousePressed)
             {
-                _window.SetMousePosition((int)_mousePressedPos.X, (int)_mousePressedPos.Y);
+                _window.CursorRelativeMode = false;
                 _window.CursorVisible = true;
                 _mousePressed = false;
             }

--- a/src/NeoVeldrid.SDL2/Sdl2Window.cs
+++ b/src/NeoVeldrid.SDL2/Sdl2Window.cs
@@ -49,20 +49,6 @@ namespace NeoVeldrid.Sdl2
         // Cursor state
         private bool _cursorRelativeMode;
 
-        // Virtual mouse mode: activated when SetMousePosition is called repeatedly
-        // to the same coordinates (the classic mouselook warp-cursor-back pattern).
-        // In this mode we use SDL relative mode + virtual position tracking instead
-        // of calling WarpMouseInWindow. This works around an SDL2 bug on Windows
-        // where SetCursorPos sets SDL_last_warp_time = GetTickCount(), and then the
-        // message pump discards all WM_MOUSEMOVE with msg.time <= SDL_last_warp_time.
-        // Since GetTickCount() has ~15ms resolution and frames can be <7ms, most real
-        // mouse events share the same tick as the warp and are silently dropped.
-        private bool _virtualMouseActive;
-        private float _virtualMouseX;
-        private float _virtualMouseY;
-        private int _lastWarpX = int.MinValue;
-        private int _lastWarpY = int.MinValue;
-
         private const int SDL_QUERY = -1;
         private const int SDL_DISABLE = 0;
         private const int SDL_ENABLE = 1;
@@ -229,16 +215,6 @@ namespace NeoVeldrid.Sdl2
             }
             set
             {
-                if (value && _virtualMouseActive)
-                {
-                    // App is showing the cursor while virtual mode is active
-                    // (e.g., mouselook ended without a warp to a new position).
-                    _sdl.SetRelativeMouseMode(SdlBool.False);
-                    _sdl.WarpMouseInWindow(_window, _currentMouseX, _currentMouseY);
-                    _virtualMouseActive = false;
-                    _lastWarpX = int.MinValue;
-                    _lastWarpY = int.MinValue;
-                }
                 int toggle = value ? SDL_ENABLE : SDL_DISABLE;
                 _sdl.ShowCursor(toggle);
             }
@@ -322,38 +298,7 @@ namespace NeoVeldrid.Sdl2
             if (!_exists)
                 return;
 
-            if (_virtualMouseActive)
-            {
-                if (x == _lastWarpX && y == _lastWarpY)
-                {
-                    // Still in mouselook - just reset virtual position.
-                    _virtualMouseX = x;
-                    _virtualMouseY = y;
-                }
-                else
-                {
-                    // Warp target changed - leave virtual mode and do a real warp.
-                    _sdl.SetRelativeMouseMode(SdlBool.False);
-                    _virtualMouseActive = false;
-                    _sdl.WarpMouseInWindow(_window, x, y);
-                }
-            }
-            else if (x == _lastWarpX && y == _lastWarpY)
-            {
-                // Second consecutive warp to the same position - mouselook detected.
-                _virtualMouseActive = true;
-                _virtualMouseX = x;
-                _virtualMouseY = y;
-                _sdl.SetRelativeMouseMode(SdlBool.True);
-            }
-            else
-            {
-                // One-off warp (or first warp to a new position). Warp normally.
-                _sdl.WarpMouseInWindow(_window, x, y);
-            }
-
-            _lastWarpX = x;
-            _lastWarpY = y;
+            _sdl.WarpMouseInWindow(_window, x, y);
             _currentMouseX = x;
             _currentMouseY = y;
             _privateSnapshot.MousePosition = new Vector2(x, y);
@@ -576,8 +521,11 @@ namespace NeoVeldrid.Sdl2
 
         private void HandleMouseWheelEvent(Silk.NET.SDL.MouseWheelEvent mouseWheelEvent)
         {
-            _privateSnapshot.WheelDelta += mouseWheelEvent.Y;
-            MouseWheel?.Invoke(new MouseWheelEventArgs(GetCurrentMouseState(), (float)mouseWheelEvent.Y));
+            // PreciseY carries sub-detent resolution from precision touchpads and high-end
+            // mice. The integer Y field rounds those down to 0, making slow scroll feel dead.
+            float delta = mouseWheelEvent.PreciseY;
+            _privateSnapshot.WheelDelta += delta;
+            MouseWheel?.Invoke(new MouseWheelEventArgs(GetCurrentMouseState(), delta));
         }
 
         private void HandleDropEvent(DropEvent dropEvent)
@@ -630,30 +578,23 @@ namespace NeoVeldrid.Sdl2
 
         private void HandleMouseMotionEvent(MouseMotionEvent mouseMotionEvent)
         {
-            Vector2 mousePos;
-            Vector2 delta = new Vector2(mouseMotionEvent.Xrel, mouseMotionEvent.Yrel);
+            // Skip spurious zero-delta motion events. SDL 2.24+ on Windows emits these
+            // continuously via raw input. Only filter when the absolute position is also
+            // unchanged: events with Xrel=Yrel=0 but a fresh X/Y are legitimate position
+            // updates SDL generates on focus-gain and mouse-enter-window, and must not be
+            // dropped or the MouseMove stream silently desyncs from the real cursor.
+            if (mouseMotionEvent.Xrel == 0 && mouseMotionEvent.Yrel == 0
+                && mouseMotionEvent.X == _currentMouseX && mouseMotionEvent.Y == _currentMouseY)
+            {
+                return;
+            }
 
-            if (_virtualMouseActive)
-            {
-                // In virtual mouse mode, SDL is in relative mode so X/Y are unreliable.
-                // Accumulate deltas onto the virtual position instead.
-                _virtualMouseX += mouseMotionEvent.Xrel;
-                _virtualMouseY += mouseMotionEvent.Yrel;
-                mousePos = new Vector2(_virtualMouseX, _virtualMouseY);
-            }
-            else
-            {
-                mousePos = new Vector2(mouseMotionEvent.X, mouseMotionEvent.Y);
-            }
+            Vector2 mousePos = new Vector2(mouseMotionEvent.X, mouseMotionEvent.Y);
+            Vector2 delta = new Vector2(mouseMotionEvent.Xrel, mouseMotionEvent.Yrel);
 
             _currentMouseX = (int)mousePos.X;
             _currentMouseY = (int)mousePos.Y;
             _privateSnapshot.MousePosition = mousePos;
-
-            if (mouseMotionEvent.Xrel == 0 && mouseMotionEvent.Yrel == 0)
-            {
-                return;
-            }
 
             if (!_firstMouseEvent)
             {


### PR DESCRIPTION
`Sdl2Window.SetMousePosition` no longer emulates the warp-cursor-back mouselook idiom. That pattern is broken on Windows under modern SDL2 - the `SDL_last_warp_time` filter drops most of the motion events it depends on - and the emulation we had couldn't reliably distinguish real mouselook from unrelated application warps to the same coordinate.

Mouselook now uses `CursorRelativeMode` + `MouseDelta`, which bypasses the warp-echo filter entirely by consuming raw input. NeoDemo's camera is migrated as part of this PR, and the migration guide documents the swap for downstream apps.

Two adjacent fixes ride along:

- Mouse wheel events now read `PreciseY` instead of `Y`. Sub-detent scrolls on precision touchpads no longer round to zero.
- The zero-delta motion filter is back to a conservative predicate. The previous one dropped legit position updates on Windows where SDL emits `Xrel=Yrel=0` with a fresh `X/Y` (focus-gain, window-enter), which silently desynced the cursor.

Headed for v1.0.0-rc.3. Breaking change is documented in `CHANGELOG.md` and the migration guide.