### PR TITLE
[Docs] Update test paths in README

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@
 Tests SPIR-V cross-compilation (HLSL, GLSL, ESSL, MSL), GLSL-to-SPIR-V compilation, shader reflection, and JSON serialization.
 
 ```bash
-dotnet test tests/Veldrid.SPIRV.Tests/Veldrid.SPIRV.Tests.csproj
+dotnet test tests/NeoVeldrid.SPIRV.Tests/NeoVeldrid.SPIRV.Tests.csproj
 ```
 
 ## GPU Tests (requires graphics hardware)
@@ -22,34 +22,34 @@ Tests buffers, textures, framebuffers, compute, rendering, pipelines, resource s
 Run all backends for the current platform:
 
 ```bash
-dotnet test tests/Veldrid.Tests/Veldrid.Tests.csproj
+dotnet test tests/NeoVeldrid.Tests/NeoVeldrid.Tests.csproj
 ```
 
 Run a specific backend only:
 
 ```bash
-dotnet test tests/Veldrid.Tests/Veldrid.Tests.csproj --filter "Backend=D3D11"
-dotnet test tests/Veldrid.Tests/Veldrid.Tests.csproj --filter "Backend=Vulkan"
-dotnet test tests/Veldrid.Tests/Veldrid.Tests.csproj --filter "Backend=OpenGL"
-dotnet test tests/Veldrid.Tests/Veldrid.Tests.csproj --filter "Backend=OpenGLES"
+dotnet test tests/NeoVeldrid.Tests/NeoVeldrid.Tests.csproj --filter "Backend=D3D11"
+dotnet test tests/NeoVeldrid.Tests/NeoVeldrid.Tests.csproj --filter "Backend=Vulkan"
+dotnet test tests/NeoVeldrid.Tests/NeoVeldrid.Tests.csproj --filter "Backend=OpenGL"
+dotnet test tests/NeoVeldrid.Tests/NeoVeldrid.Tests.csproj --filter "Backend=OpenGLES"
 ```
 
 Run multiple backends:
 
 ```bash
-dotnet test tests/Veldrid.Tests/Veldrid.Tests.csproj --filter "Backend=D3D11|Backend=Vulkan"
+dotnet test tests/NeoVeldrid.Tests/NeoVeldrid.Tests.csproj --filter "Backend=D3D11|Backend=Vulkan"
 ```
 
 Run a specific test across all backends:
 
 ```bash
-dotnet test tests/Veldrid.Tests/Veldrid.Tests.csproj --filter "Map_WrongFlags_Throws"
+dotnet test tests/NeoVeldrid.Tests/NeoVeldrid.Tests.csproj --filter "Map_WrongFlags_Throws"
 ```
 
 Run only non-GPU tests (for CI or machines without graphics hardware):
 
 ```bash
-dotnet test tests/Veldrid.Tests/Veldrid.Tests.csproj -p:ExcludeGPU=true
+dotnet test tests/NeoVeldrid.Tests/NeoVeldrid.Tests.csproj -p:ExcludeGPU=true
 ```
 
 ### Skipped tests


### PR DESCRIPTION
The test project folders are named `NeoVeldrid.Tests` and `NeoVeldrid.SPIRV.Tests`, but the README still referenced the old upstream `Veldrid.Tests` / `Veldrid.SPIRV.Tests` paths from before the rename. All `dotnet test` snippets fail to find the project as a result. Updated the paths to match the actual folder names.