### PR TITLE
[OpenGL] Fix SymbolLoadingException on shutdown

### DIFF
--- a/src/NeoVeldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -1,5 +1,6 @@
 ﻿using static NeoVeldrid.OpenGL.OpenGLUtil;
 using System;
+using Silk.NET.Core.Loader;
 using Silk.NET.OpenGL;
 using Silk.NET.OpenGL.Extensions.EXT;
 using GLPixelFormat = Silk.NET.OpenGL.PixelFormat;
@@ -995,16 +996,16 @@ namespace NeoVeldrid.OpenGL
                         {
                             try
                             {
-                                // Check if the OpenGL context has already been destroyed by the OS. If so, just exit out.
-                                uint error = (uint)_gd.GL.GetError();
-                                if (error == (uint)ErrorCode.InvalidOperation)
+                                try
                                 {
-                                    return;
+                                    _makeCurrent(_gd._glContext);
+                                    _gd.FlushDisposables();
+                                    _gd._deleteContext(_gd._glContext);
                                 }
-                                _makeCurrent(_gd._glContext);
-
-                                _gd.FlushDisposables();
-                                _gd._deleteContext(_gd._glContext);
+                                catch (SymbolLoadingException)
+                                {
+                                    // Context already destroyed by the OS. Nothing to clean up via GL.
+                                }
                                 _gd.StagingMemoryPool.Dispose();
                             }
                             finally
@@ -1039,6 +1040,10 @@ namespace NeoVeldrid.OpenGL
                                     _gd.GL.Flush();
                                     _gd.GL.Finish();
                                 }
+                            }
+                            catch (SymbolLoadingException)
+                            {
+                                // Context destroyed before the work item ran. Flush is moot; finally releases the caller.
                             }
                             finally
                             {


### PR DESCRIPTION
`OpenGLGraphicsDevice.ExecutionThread` could throw `SymbolLoadingException` on shutdown when the OS reclaimed the GL context before queued work items drained. The race exists in upstream Veldrid too, but upstream uses static P/Invoke - calls into a destroyed context silently no-op rather than throwing. Silk.NET resolves GL entry points lazily through the context, so the same race surfaces as a managed exception in NeoVeldrid. Production builds caught it via the outer `catch (Exception e) when (!Debugger.IsAttached)`; debugger sessions saw it propagate.

Two targeted catches:

- `WaitForIdle`: catch `SymbolLoadingException` around the GL calls. The existing finally still releases the caller's MRE.
- `TerminateAction`: drop the upstream-inherited `glGetError() == InvalidOperation` probe (which never fires under Silk.NET because resolution throws first). Replace with try/catch around the GL-using cleanup steps. Also incidentally fixes a small leak: `StagingMemoryPool.Dispose()` now runs unconditionally instead of being skipped when the probe short-circuited.

Verified locally with the full GPU test suite across all platform-supported backends (D3D11, Vulkan, OpenGL, OpenGLES) - 1645 passed, 0 failed. Headed for v1.0.0-rc.3.