### PR TITLE
[Samples] Fix AnimatedMesh sample rendering black on OpenGL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ First release of NeoVeldrid. A maintained, drop-in replacement for [Veldrid](htt
 - [Vulkan] Fixes `CreateLogicalDevice` ignoring the present queue family on GPUs where it differs from the graphics family.
 - [SDL2] Scroll-to-zoom now respects sub-detent deltas from precision touchpads and high-end mice. Slow scrolls no longer round to zero.
 - [SDL2] Cursor position no longer desyncs when the window regains focus or the pointer re-enters the window on Windows. Modern SDL2 emits zero-delta motion events in those cases, and the previous filter discarded them too aggressively.
+- [Samples] The AnimatedMesh sample now renders correctly on OpenGL and OpenGL ES.
 
 [Unreleased]: https://github.com/jhm-ciberman/neo-veldrid/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/jhm-ciberman/neo-veldrid/releases/tag/v1.0.0

--- a/samples/AnimatedMesh/Application/AnimatedMesh.cs
+++ b/samples/AnimatedMesh/Application/AnimatedMesh.cs
@@ -53,10 +53,10 @@ namespace AnimatedMesh
             GraphicsDevice.UpdateBuffer(_worldBuffer, 0, ref worldMatrix);
 
             ResourceLayout layout = factory.CreateResourceLayout(new ResourceLayoutDescription(
-                new ResourceLayoutElementDescription("Projection", ResourceKind.UniformBuffer, ShaderStages.Vertex),
-                new ResourceLayoutElementDescription("View", ResourceKind.UniformBuffer, ShaderStages.Vertex),
-                new ResourceLayoutElementDescription("World", ResourceKind.UniformBuffer, ShaderStages.Vertex),
-                new ResourceLayoutElementDescription("Bones", ResourceKind.UniformBuffer, ShaderStages.Vertex),
+                new ResourceLayoutElementDescription("ProjectionBuffer", ResourceKind.UniformBuffer, ShaderStages.Vertex),
+                new ResourceLayoutElementDescription("ViewBuffer", ResourceKind.UniformBuffer, ShaderStages.Vertex),
+                new ResourceLayoutElementDescription("WorldBuffer", ResourceKind.UniformBuffer, ShaderStages.Vertex),
+                new ResourceLayoutElementDescription("BonesBuffer", ResourceKind.UniformBuffer, ShaderStages.Vertex),
                 new ResourceLayoutElementDescription("SurfaceTex", ResourceKind.TextureReadOnly, ShaderStages.Fragment),
                 new ResourceLayoutElementDescription("SurfaceSampler", ResourceKind.Sampler, ShaderStages.Fragment)));
 


### PR DESCRIPTION
The AnimatedMesh sample rendered a completely black window on OpenGL and OpenGL ES while working fine on Vulkan and D3D11.

The shader declares its uniform blocks as `ProjectionBuffer`, `ViewBuffer`, `WorldBuffer`, `BonesBuffer`, but the `ResourceLayout` was asking for `Projection`, `View`, `World`, `Bones`. OpenGL resolves uniform-block bindings by name through `glGetUniformBlockIndex`, so each lookup returned `GL_INVALID_INDEX`, the backend quietly skipped the binding, and the shader saw zero matrices for everything - every vertex collapsed to the origin. Vulkan and D3D11 bind by `(set, binding)` / `register` slot, so the name mismatch was invisible there.

Fix is just renaming the four `ResourceLayoutElementDescription` entries to match the block names, same convention the TexturedCube sample already uses.