### PR TITLE
[D3D11] Default structured buffers to raw HLSL binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ First release of NeoVeldrid. A maintained, drop-in replacement for [Veldrid](htt
 ### Breaking
 
 - `Sdl2Window.SetMousePosition` no longer supports per-frame warp-cursor-back mouselook. Code using that pattern must switch to `CursorRelativeMode` + `MouseDelta`. See the [Migration Guide](docs/articles/prologue/migration.md#mouselook-with-setmouseposition).
+- `BufferDescription.RawBuffer` has been renamed to `BufferDescription.UseTypedHlslBinding` and its default behavior flipped. Structured buffers now bind as `(RW)ByteAddressBuffer` on D3D11 by default, matching the HLSL that `NeoVeldrid.SPIRV` generates from GLSL. Users binding hand-written HLSL that declares its storage buffers as `(RW)StructuredBuffer<T>` must set `UseTypedHlslBinding = true`.
 
 ### Changed
 
@@ -49,6 +50,7 @@ First release of NeoVeldrid. A maintained, drop-in replacement for [Veldrid](htt
 - [SDL2] Scroll-to-zoom now respects sub-detent deltas from precision touchpads and high-end mice. Slow scrolls no longer round to zero.
 - [SDL2] Cursor position no longer desyncs when the window regains focus or the pointer re-enters the window on Windows. Modern SDL2 emits zero-delta motion events in those cases, and the previous filter discarded them too aggressively.
 - [Samples] The AnimatedMesh sample now renders correctly on OpenGL and OpenGL ES.
+- [Samples] The ComputeParticles sample now renders correctly on D3D11.
 
 [Unreleased]: https://github.com/jhm-ciberman/neo-veldrid/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/jhm-ciberman/neo-veldrid/releases/tag/v1.0.0

--- a/docs/articles/prologue/migration.md
+++ b/docs/articles/prologue/migration.md
@@ -155,3 +155,31 @@ _window.CursorRelativeMode = false;
 While `CursorRelativeMode` is active, the cursor is hidden and confined to the window; disabling it restores the original position.
 
 Note the `+=` becomes `-=`. `_anchor - snapshot.MousePosition` measures how far the cursor has drifted from the anchor; `MouseDelta` measures how far it has moved since the previous frame. Same magnitude, opposite sign.
+
+### Structured Buffer Default Changed on Direct3D11
+
+**Likelihood Of Impact: Low**
+
+**If you use `NeoVeldrid.SPIRV` to cross-compile GLSL shaders (the standard path):** no code changes are required. If you were explicitly passing `rawBuffer: true`, you can now drop the argument. The new default matches.
+
+```csharp
+// Veldrid
+new BufferDescription(size, BufferUsage.StructuredBufferReadWrite, stride, rawBuffer: true);
+
+// NeoVeldrid
+new BufferDescription(size, BufferUsage.StructuredBufferReadWrite, stride);
+```
+
+**If you bind hand-written HLSL that uses typed structured buffers** (`StructuredBuffer<T>` / `RWStructuredBuffer<T>` rather than `ByteAddressBuffer`), set `UseTypedHlslBinding = true`:
+
+```csharp
+// Veldrid
+new BufferDescription(size, BufferUsage.StructuredBufferReadWrite, stride, rawBuffer: false);
+
+// NeoVeldrid
+new BufferDescription(size, BufferUsage.StructuredBufferReadWrite, stride, useTypedHlslBinding: true);
+```
+
+#### What changed
+
+`BufferDescription.RawBuffer` was renamed to `BufferDescription.UseTypedHlslBinding` with the default behavior flipped. On D3D11, structured buffers now bind as raw `(RW)ByteAddressBuffer` by default. `UseTypedHlslBinding` has no effect on Vulkan, OpenGL, or OpenGL ES.

--- a/docs/articles/shaders/shader-resource-table.md
+++ b/docs/articles/shaders/shader-resource-table.md
@@ -15,4 +15,4 @@ When authoring shader code, you need to keep in mind the types of resources you 
 | TextureReadWrite | image(2D,3D) | RWTexture(2D,3D) | texture(2d,3d) with access::read_write |
 | Sampler | sampler (Vulkan), Not supported in OpenGL, see [Shaders](xref:shaders-and-resources#sampler) | SamplerState | sampler |
 
-* (RW)ByteAddressBuffer can only be used with a DeviceBuffer that was created with [BufferDescription.RawBuffer](xref:NeoVeldrid.BufferDescription#NeoVeldrid_BufferDescription_RawBuffer) set to true.
+* On D3D11, a structured buffer is bound as `(RW)ByteAddressBuffer` by default (matches the HLSL that `NeoVeldrid.SPIRV` generates from GLSL). Set [BufferDescription.UseTypedHlslBinding](xref:NeoVeldrid.BufferDescription#NeoVeldrid_BufferDescription_UseTypedHlslBinding) to `true` when binding hand-written HLSL that declares its storage buffers as `(RW)StructuredBuffer<T>`.

--- a/src/NeoVeldrid/BufferDescription.cs
+++ b/src/NeoVeldrid/BufferDescription.cs
@@ -22,10 +22,14 @@ namespace NeoVeldrid
         /// </summary>
         public uint StructureByteStride;
         /// <summary>
-        /// Indicates that this is a raw buffer. This should be combined with
-        /// <see cref="BufferUsage.StructuredBufferReadWrite"/>. This affects how the buffer is bound in the D3D11 backend.
+        /// Controls how a structured buffer is bound on HLSL-based backends (D3D11). Only meaningful when
+        /// <see cref="Usage"/> includes <see cref="BufferUsage.StructuredBufferReadOnly"/> or
+        /// <see cref="BufferUsage.StructuredBufferReadWrite"/>. When true, binds as a typed
+        /// <c>(RW)StructuredBuffer&lt;T&gt;</c>; use this when binding hand-written HLSL that declares its
+        /// storage buffers with those types. When false (default), binds as a raw <c>(RW)ByteAddressBuffer</c>.
+        /// Has no effect on non-HLSL backends.
         /// </summary>
-        public bool RawBuffer;
+        public bool UseTypedHlslBinding;
 
         /// <summary>
         /// Constructs a new <see cref="BufferDescription"/> describing a non-dynamic <see cref="DeviceBuffer"/>.
@@ -37,7 +41,7 @@ namespace NeoVeldrid
             SizeInBytes = sizeInBytes;
             Usage = usage;
             StructureByteStride = 0;
-            RawBuffer = false;
+            UseTypedHlslBinding = false;
         }
 
         /// <summary>
@@ -52,7 +56,7 @@ namespace NeoVeldrid
             SizeInBytes = sizeInBytes;
             Usage = usage;
             StructureByteStride = structureByteStride;
-            RawBuffer = false;
+            UseTypedHlslBinding = false;
         }
 
         /// <summary>
@@ -62,15 +66,18 @@ namespace NeoVeldrid
         /// <param name="usage">Indicates how the <see cref="DeviceBuffer"/> will be used.</param>
         /// <param name="structureByteStride">For structured buffers, this value indicates the size in bytes of a single
         /// structure element, and must be non-zero. For all other buffer types, this value must be zero.</param>
-        /// <param name="rawBuffer">Indicates that this is a raw buffer. This should be combined with
-        /// <see cref="BufferUsage.StructuredBufferReadWrite"/>. This affects how the buffer is bound in the D3D11 backend.
-        /// </param>
-        public BufferDescription(uint sizeInBytes, BufferUsage usage, uint structureByteStride, bool rawBuffer)
+        /// <param name="useTypedHlslBinding">Controls how a structured buffer is bound on HLSL-based backends (D3D11).
+        /// Only meaningful when <paramref name="usage"/> includes <see cref="BufferUsage.StructuredBufferReadOnly"/> or
+        /// <see cref="BufferUsage.StructuredBufferReadWrite"/>. When true, binds as a typed
+        /// <c>(RW)StructuredBuffer&lt;T&gt;</c>; use this when binding hand-written HLSL that declares its storage
+        /// buffers with those types. When false, binds as a raw <c>(RW)ByteAddressBuffer</c>. Has no effect on
+        /// non-HLSL backends.</param>
+        public BufferDescription(uint sizeInBytes, BufferUsage usage, uint structureByteStride, bool useTypedHlslBinding)
         {
             SizeInBytes = sizeInBytes;
             Usage = usage;
             StructureByteStride = structureByteStride;
-            RawBuffer = rawBuffer;
+            UseTypedHlslBinding = useTypedHlslBinding;
         }
 
         /// <summary>
@@ -83,7 +90,7 @@ namespace NeoVeldrid
             return SizeInBytes.Equals(other.SizeInBytes)
                 && Usage == other.Usage
                 && StructureByteStride.Equals(other.StructureByteStride)
-                && RawBuffer.Equals(other.RawBuffer);
+                && UseTypedHlslBinding.Equals(other.UseTypedHlslBinding);
         }
 
         /// <summary>
@@ -96,7 +103,7 @@ namespace NeoVeldrid
                 SizeInBytes.GetHashCode(),
                 (int)Usage,
                 StructureByteStride.GetHashCode(),
-                RawBuffer.GetHashCode());
+                UseTypedHlslBinding.GetHashCode());
         }
     }
 }

--- a/src/NeoVeldrid/D3D11/D3D11Buffer.cs
+++ b/src/NeoVeldrid/D3D11/D3D11Buffer.cs
@@ -16,7 +16,7 @@ namespace NeoVeldrid.D3D11
         private readonly Dictionary<OffsetSizePair, ComPtr<ID3D11UnorderedAccessView>> _uavs
             = new Dictionary<OffsetSizePair, ComPtr<ID3D11UnorderedAccessView>>();
         private readonly uint _structureByteStride;
-        private readonly bool _rawBuffer;
+        private readonly bool _useTypedHlslBinding;
         private string _name;
         private bool _disposed;
 
@@ -28,13 +28,13 @@ namespace NeoVeldrid.D3D11
 
         public ID3D11Buffer* Buffer => _buffer;
 
-        public D3D11Buffer(ID3D11Device* device, uint sizeInBytes, BufferUsage usage, uint structureByteStride, bool rawBuffer)
+        public D3D11Buffer(ID3D11Device* device, uint sizeInBytes, BufferUsage usage, uint structureByteStride, bool useTypedHlslBinding)
         {
             _device = device;
             SizeInBytes = sizeInBytes;
             Usage = usage;
             _structureByteStride = structureByteStride;
-            _rawBuffer = rawBuffer;
+            _useTypedHlslBinding = useTypedHlslBinding;
 
             BufferDesc bd = new BufferDesc
             {
@@ -46,14 +46,14 @@ namespace NeoVeldrid.D3D11
             if ((usage & BufferUsage.StructuredBufferReadOnly) == BufferUsage.StructuredBufferReadOnly
                 || (usage & BufferUsage.StructuredBufferReadWrite) == BufferUsage.StructuredBufferReadWrite)
             {
-                if (rawBuffer)
-                {
-                    bd.MiscFlags = (uint)ResourceMiscFlag.BufferAllowRawViews;
-                }
-                else
+                if (useTypedHlslBinding)
                 {
                     bd.MiscFlags = (uint)ResourceMiscFlag.BufferStructured;
                     bd.StructureByteStride = structureByteStride;
+                }
+                else
+                {
+                    bd.MiscFlags = (uint)ResourceMiscFlag.BufferAllowRawViews;
                 }
             }
 
@@ -144,19 +144,19 @@ namespace NeoVeldrid.D3D11
         {
             ShaderResourceViewDesc srvDesc = new ShaderResourceViewDesc();
 
-            if (_rawBuffer)
+            if (_useTypedHlslBinding)
+            {
+                srvDesc.ViewDimension = D3DSrvDimension.D3DSrvDimensionBuffer;
+                srvDesc.Buffer.FirstElement = offset / _structureByteStride;
+                srvDesc.Buffer.NumElements = size / _structureByteStride;
+            }
+            else
             {
                 srvDesc.Format = Format.FormatR32Typeless;
                 srvDesc.ViewDimension = D3DSrvDimension.D3DSrvDimensionBufferex;
                 srvDesc.BufferEx.FirstElement = offset / 4;
                 srvDesc.BufferEx.NumElements = size / 4;
                 srvDesc.BufferEx.Flags = (uint)BufferexSrvFlag.Raw;
-            }
-            else
-            {
-                srvDesc.ViewDimension = D3DSrvDimension.D3DSrvDimensionBuffer;
-                srvDesc.Buffer.FirstElement = offset / _structureByteStride;
-                srvDesc.Buffer.NumElements = size / _structureByteStride;
             }
 
             ID3D11ShaderResourceView* pSrv;
@@ -173,18 +173,18 @@ namespace NeoVeldrid.D3D11
                 ViewDimension = UavDimension.Buffer,
             };
 
-            if (_rawBuffer)
+            if (_useTypedHlslBinding)
+            {
+                uavDesc.Format = Format.FormatUnknown;
+                uavDesc.Buffer.FirstElement = offset / _structureByteStride;
+                uavDesc.Buffer.NumElements = size / _structureByteStride;
+            }
+            else
             {
                 uavDesc.Format = Format.FormatR32Typeless;
                 uavDesc.Buffer.FirstElement = offset / 4;
                 uavDesc.Buffer.NumElements = size / 4;
                 uavDesc.Buffer.Flags = (uint)BufferUavFlag.Raw;
-            }
-            else
-            {
-                uavDesc.Format = Format.FormatUnknown;
-                uavDesc.Buffer.FirstElement = offset / _structureByteStride;
-                uavDesc.Buffer.NumElements = size / _structureByteStride;
             }
 
             ID3D11UnorderedAccessView* pUav;

--- a/src/NeoVeldrid/D3D11/D3D11ResourceFactory.cs
+++ b/src/NeoVeldrid/D3D11/D3D11ResourceFactory.cs
@@ -84,7 +84,7 @@ namespace NeoVeldrid.D3D11
                 description.SizeInBytes,
                 description.Usage,
                 description.StructureByteStride,
-                description.RawBuffer);
+                description.UseTypedHlslBinding);
         }
 
         public override Fence CreateFence(bool signaled)

--- a/tests/NeoVeldrid.Tests/ComputeTests.cs
+++ b/tests/NeoVeldrid.Tests/ComputeTests.cs
@@ -194,8 +194,8 @@ void main()
             uint width = 1024;
             uint height = 1024;
             DeviceBuffer paramsBuffer = RF.CreateBuffer(new BufferDescription((uint)Unsafe.SizeOf<BasicComputeTestParams>(), BufferUsage.UniformBuffer));
-            DeviceBuffer sourceBuffer = RF.CreateBuffer(new BufferDescription(width * height * 4, BufferUsage.StructuredBufferReadWrite, 4, true));
-            DeviceBuffer destinationBuffer = RF.CreateBuffer(new BufferDescription(width * height * 4, BufferUsage.StructuredBufferReadWrite, 4, true));
+            DeviceBuffer sourceBuffer = RF.CreateBuffer(new BufferDescription(width * height * 4, BufferUsage.StructuredBufferReadWrite, 4));
+            DeviceBuffer destinationBuffer = RF.CreateBuffer(new BufferDescription(width * height * 4, BufferUsage.StructuredBufferReadWrite, 4));
 
             GD.UpdateBuffer(paramsBuffer, 0, new BasicComputeTestParams { Width = width, Height = height });
 
@@ -410,9 +410,9 @@ void main()
             uint totalDstAlignment = GD.StructuredBufferMinOffsetAlignment * (dstSetMultiple + dstBindingMultiple);
 
             DeviceBuffer copySrc = RF.CreateBuffer(
-                new BufferDescription(totalSrcAlignment + dataSize, BufferUsage.StructuredBufferReadOnly, sizeof(uint), true));
+                new BufferDescription(totalSrcAlignment + dataSize, BufferUsage.StructuredBufferReadOnly, sizeof(uint)));
             DeviceBuffer copyDst = RF.CreateBuffer(
-                new BufferDescription(totalDstAlignment + dataSize, BufferUsage.StructuredBufferReadWrite, sizeof(uint), true));
+                new BufferDescription(totalDstAlignment + dataSize, BufferUsage.StructuredBufferReadWrite, sizeof(uint)));
 
             ResourceLayout[] layouts;
             ResourceSet[] sets;

--- a/tests/NeoVeldrid.Tests/RenderTests.cs
+++ b/tests/NeoVeldrid.Tests/RenderTests.cs
@@ -741,8 +741,7 @@ namespace NeoVeldrid.Tests
             DeviceBuffer buffer = RF.CreateBuffer(new BufferDescription(
                 vertexSize * 4,
                 BufferUsage.StructuredBufferReadWrite,
-                vertexSize,
-                true));
+                vertexSize));
 
             ResourceLayout computeLayout = RF.CreateResourceLayout(new ResourceLayoutDescription(
                 new ResourceLayoutElementDescription("OutputVertices", ResourceKind.StructuredBufferReadWrite, ShaderStages.Compute)));
@@ -1324,8 +1323,7 @@ namespace NeoVeldrid.Tests
             using var buffer = RF.CreateBuffer(new BufferDescription(
                 vertexSize * (uint)vertices.Length,
                 BufferUsage.StructuredBufferReadOnly,
-                vertexSize,
-                true));
+                vertexSize));
             GD.UpdateBuffer(buffer, 0, vertices);
 
             using var graphicsLayout = RF.CreateResourceLayout(new ResourceLayoutDescription(
@@ -1434,8 +1432,7 @@ namespace NeoVeldrid.Tests
             using var buffer = RF.CreateBuffer(new BufferDescription(
                 vertexSize * (uint)vertices.Length,
                 BufferUsage.StructuredBufferReadOnly,
-                vertexSize,
-                true));
+                vertexSize));
             GD.UpdateBuffer(buffer, 0, vertices);
 
             using var graphicsLayout = RF.CreateResourceLayout(new ResourceLayoutDescription(


### PR DESCRIPTION
`ComputeParticles` renders every particle crushed into the bottom pixel row on D3D11 while working fine on Vulkan. Root cause is in the buffer-creation API.

`NeoVeldrid.SPIRV` always cross-compiles GLSL SSBOs to HLSL `(RW)ByteAddressBuffer` - SPIRV-Cross's hardcoded choice, to faithfully preserve SPIR-V's byte-offset access semantics. That requires the backing D3D11 buffer to be created with `ResourceMiscFlag.BufferAllowRawViews`, but `BufferDescription` defaulted `RawBuffer` to `false`, producing a `BufferStructured` buffer. D3D11 doesn't diagnose the mismatch - it returns zeros, so every shader's `Particles[i].Position.y` read collapses to 0 and all particles land on the bottom row. Vulkan is immune because SPIR-V SSBOs don't have a raw/structured API distinction.

`BufferDescription.RawBuffer` is renamed to `BufferDescription.UseTypedHlslBinding` and the default flipped. `false` (now the default) produces the raw-view buffer the SPIRV-Cross path needs. Users binding hand-written HLSL with `(RW)StructuredBuffer<T>` opt in with `UseTypedHlslBinding = true`. The rename also scopes the name to the only backend where the flag does anything.

Breaking change. Documented in `CHANGELOG.md` and the migration guide.