### PR TITLE
[D3D11] Remove UWP swapchain support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ First release of NeoVeldrid. A maintained, drop-in replacement for [Veldrid](htt
 - `Sdl2Native` static class. Reach the underlying SDL API through `Sdl2Window.SdlInstance` instead.
 - `Veldrid.VirtualReality` project. There was no VR hardware available for testing, so it would have rotted into dead code.
 - Android and iOS sample projects. The core library still works on those platforms, but the samples are unmaintained. Contributions welcome.
+- UWP swapchain support (`SwapchainSource.CreateUwp` and the `ISwapChainPanelNative`-taking `GraphicsDevice.CreateD3D11` overload). Microsoft deprecated UWP in 2023.
 
 ### Fixed
 

--- a/docs/articles/advanced/implementation/d3d11.md
+++ b/docs/articles/advanced/implementation/d3d11.md
@@ -1,9 +1,6 @@
 # Direct3D 11 Backend
 
-The Direct3D 11 backend is a Windows-specific backend implemented using the Direct3D 11 graphics API. A Direct3D 11 [GraphicsDevice](xref:NeoVeldrid.GraphicsDevice) can be created two ways:
-
-* Using a Win32 window handle. This can be the handle of an embedded frame within a parent window, or simply the handle of an isolated application window.
-* Using a UWP SwapChainPanel or SwapChainBackgroundPanel.
+The Direct3D 11 backend is a Windows-specific backend implemented using the Direct3D 11 graphics API. A Direct3D 11 [GraphicsDevice](xref:NeoVeldrid.GraphicsDevice) is created from a Win32 window handle, either the handle of an embedded frame within a parent window or the handle of an isolated application window.
 
 ## API Concept Map
 

--- a/src/NeoVeldrid/D3D11/D3D11Swapchain.cs
+++ b/src/NeoVeldrid/D3D11/D3D11Swapchain.cs
@@ -94,10 +94,6 @@ namespace NeoVeldrid.D3D11
                 _dxgiSwapChain = default;
                 _dxgiSwapChain.Handle = pSwapChain;
             }
-            else if (description.Source is UwpSwapchainSource)
-            {
-                throw new PlatformNotSupportedException("UWP swap chains are not supported in this desktop-only build.");
-            }
             else
             {
                 throw new NeoVeldridException($"Unsupported swapchain source type: {description.Source?.GetType().Name}");

--- a/src/NeoVeldrid/GraphicsDevice.cs
+++ b/src/NeoVeldrid/GraphicsDevice.cs
@@ -39,7 +39,7 @@ namespace NeoVeldrid
 
         /// <summary>
         /// Gets a value identifying whether texture coordinates begin in the top left corner of a Texture.
-        /// If true, (0, 0) refers to the top-left texel of a Texture. If false, (0, 0) refers to the bottom-left 
+        /// If true, (0, 0) refers to the top-left texel of a Texture. If false, (0, 0) refers to the bottom-left
         /// texel of a Texture. This property is useful for determining how the output of a Framebuffer should be sampled.
         /// </summary>
         public abstract bool IsUvOriginTopLeft { get; }
@@ -1030,35 +1030,6 @@ namespace NeoVeldrid
             SwapchainDescription swapchainDescription = new SwapchainDescription(
                 SwapchainSource.CreateWin32(hwnd, IntPtr.Zero),
                 width, height,
-                options.SwapchainDepthFormat,
-                options.SyncToVerticalBlank,
-                options.SwapchainSrgbFormat);
-
-            return new D3D11.D3D11GraphicsDevice(options, new D3D11DeviceOptions(), swapchainDescription);
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="GraphicsDevice"/> using Direct3D 11, with a main Swapchain.
-        /// </summary>
-        /// <param name="options">Describes several common properties of the GraphicsDevice.</param>
-        /// <param name="swapChainPanel">A COM object which must implement the ISwapChainPanelNative
-        /// or ISwapChainBackgroundPanelNative interface. Generally, this should be a SwapChainPanel
-        /// or SwapChainBackgroundPanel contained in your application window.</param>
-        /// <param name="renderWidth">The renderable width of the swapchain panel.</param>
-        /// <param name="renderHeight">The renderable height of the swapchain panel.</param>
-        /// <param name="logicalDpi">The logical DPI of the swapchain panel.</param>
-        /// <returns></returns>
-        public static GraphicsDevice CreateD3D11(
-            GraphicsDeviceOptions options,
-            object swapChainPanel,
-            double renderWidth,
-            double renderHeight,
-            float logicalDpi)
-        {
-            SwapchainDescription swapchainDescription = new SwapchainDescription(
-                SwapchainSource.CreateUwp(swapChainPanel, logicalDpi),
-                (uint)renderWidth,
-                (uint)renderHeight,
                 options.SwapchainDepthFormat,
                 options.SyncToVerticalBlank,
                 options.SwapchainSrgbFormat);

--- a/src/NeoVeldrid/SwapchainSource.cs
+++ b/src/NeoVeldrid/SwapchainSource.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 
 namespace NeoVeldrid
 {
@@ -20,18 +19,6 @@ namespace NeoVeldrid
         /// <returns>A new SwapchainSource which can be used to create a <see cref="Swapchain"/> for the given Win32 window.
         /// </returns>
         public static SwapchainSource CreateWin32(IntPtr hwnd, IntPtr hinstance) => new Win32SwapchainSource(hwnd, hinstance);
-
-        /// <summary>
-        /// Creates a new SwapchainSource for a UWP SwapChain panel.
-        /// </summary>
-        /// <param name="swapChainPanel">A COM object which must implement the ISwapChainPanelNative
-        /// or ISwapChainBackgroundPanelNative interface. Generally, this should be a SwapChainPanel
-        /// or SwapChainBackgroundPanel contained in your application window.</param>
-        /// <param name="logicalDpi">The logical DPI of the swapchain panel.</param>
-        /// <returns>A new SwapchainSource which can be used to create a <see cref="Swapchain"/> for the given UWP panel.
-        /// </returns>
-        public static SwapchainSource CreateUwp(object swapChainPanel, float logicalDpi)
-            => new UwpSwapchainSource(swapChainPanel, logicalDpi);
 
         /// <summary>
         /// Creates a new SwapchainSource from the given Xlib information.
@@ -98,18 +85,6 @@ namespace NeoVeldrid
         {
             Hwnd = hwnd;
             Hinstance = hinstance;
-        }
-    }
-
-    internal class UwpSwapchainSource : SwapchainSource
-    {
-        public object SwapChainPanelNative { get; }
-        public float LogicalDpi { get; }
-
-        public UwpSwapchainSource(object swapChainPanelNative, float logicalDpi)
-        {
-            SwapChainPanelNative = swapChainPanelNative;
-            LogicalDpi = logicalDpi;
         }
     }
 


### PR DESCRIPTION
`SwapchainSource.CreateUwp` and the `object swapChainPanel`-taking `GraphicsDevice.CreateD3D11` overload have been stubs since the Silk.NET port - the D3D11 swapchain constructor threw `PlatformNotSupportedException` the moment it saw a `UwpSwapchainSource`. Upstream Veldrid implemented the UWP COM wiring through Vortice's `ISwapChainPanelNative` projection, which got dropped along with the Vortice dependency. Silk.NET doesn't ship that XAML-side interface, so the port left the public API surface intact with a throwing implementation rather than reimplement.

Microsoft deprecated UWP in 2023. No in-repo callers, no sample usage, and anyone calling this in the wild was getting a runtime exception anyway. Removing the API surface turns a ghost API (passes typecheck, fails at runtime) into an honest compile error.

Deletes the factory + internal class in `SwapchainSource`, the UWP `CreateD3D11` overload, the throwing branch in `D3D11Swapchain`, and a stray `using System.Runtime.InteropServices;`. WinUI 3 / `SwapChainPanel` integration was never implemented; it's a tractable future addition since `Silk.NET.DXGI` exposes `CreateSwapChainForComposition`.

Verified D3D11 GPU suite: 438 passed, 0 failed.