### PR TITLE
[ImGui] Defer first frame for pre-init configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `[ImGui]` `ImGuiRenderer` now accepts an `autoInit: false` constructor option and exposes a public `Initialize()` method, so callers can configure `ImGui.GetIO()` (docking flags, custom fonts, etc.) before the first ImGui frame is opened.
+
 ## [1.0.0] - 2026-04-25
 
 First release of NeoVeldrid. A maintained, drop-in replacement for [Veldrid](https://github.com/mellinoe/veldrid) with every native binding replaced by [Silk.NET](https://github.com/dotnet/Silk.NET). If you have a Veldrid project today, migrating is roughly a 5 minute find-and-replace. See the [Migration Guide](docs/articles/prologue/migration.md) for the exact steps.

--- a/src/NeoVeldrid.ImGui/ImGuiRenderer.cs
+++ b/src/NeoVeldrid.ImGui/ImGuiRenderer.cs
@@ -52,8 +52,11 @@ namespace NeoVeldrid
         /// <param name="outputDescription">The output format.</param>
         /// <param name="width">The initial width of the rendering target. Can be resized.</param>
         /// <param name="height">The initial height of the rendering target. Can be resized.</param>
-        public ImGuiRenderer(GraphicsDevice gd, OutputDescription outputDescription, int width, int height)
-            : this(gd, outputDescription, width, height, ColorSpaceHandling.Legacy) { }
+        /// <param name="autoInit">When <c>true</c>, opens the first ImGui frame as part of construction.
+        /// Pass <c>false</c> to configure <c>ImGui.GetIO()</c> (docking flags, fonts, style, etc.)
+        /// before the first frame, then call <see cref="Initialize"/>.</param>
+        public ImGuiRenderer(GraphicsDevice gd, OutputDescription outputDescription, int width, int height, bool autoInit = true)
+            : this(gd, outputDescription, width, height, ColorSpaceHandling.Legacy, autoInit) { }
 
         /// <summary>
         /// Constructs a new ImGuiRenderer.
@@ -63,7 +66,10 @@ namespace NeoVeldrid
         /// <param name="width">The initial width of the rendering target. Can be resized.</param>
         /// <param name="height">The initial height of the rendering target. Can be resized.</param>
         /// <param name="colorSpaceHandling">Identifies how the renderer should treat vertex colors.</param>
-        public ImGuiRenderer(GraphicsDevice gd, OutputDescription outputDescription, int width, int height, ColorSpaceHandling colorSpaceHandling)
+        /// <param name="autoInit">When <c>true</c>, opens the first ImGui frame as part of construction.
+        /// Pass <c>false</c> to configure <c>ImGui.GetIO()</c> (docking flags, fonts, style, etc.)
+        /// before the first frame, then call <see cref="Initialize"/>.</param>
+        public ImGuiRenderer(GraphicsDevice gd, OutputDescription outputDescription, int width, int height, ColorSpaceHandling colorSpaceHandling, bool autoInit = true)
         {
             _gd = gd;
             _assembly = typeof(ImGuiRenderer).GetTypeInfo().Assembly;
@@ -80,6 +86,30 @@ namespace NeoVeldrid
             CreateDeviceResources(gd, outputDescription);
 
             SetPerFrameImGuiData(1f / 60f);
+
+            if (autoInit)
+            {
+                Initialize();
+            }
+        }
+
+        /// <summary>
+        /// Opens the first ImGui frame, completing the renderer's setup so it is ready to receive
+        /// ImGui draw commands. Has no effect if a frame is already in progress.
+        /// </summary>
+        /// <remarks>
+        /// Only needed when the renderer was constructed with <c>autoInit: false</c>, which defers
+        /// opening the first frame so that callers can configure ImGui state that must be set before
+        /// the very first <c>NewFrame</c> call (for example <see cref="ImGuiNET.ImGuiConfigFlags.DockingEnable"/>,
+        /// custom fonts loaded via <c>ImGui.GetIO().Fonts</c>, or backend flags). After construction
+        /// with <c>autoInit: true</c> (the default) this is already taken care of.
+        /// </remarks>
+        public void Initialize()
+        {
+            if (_frameBegun)
+            {
+                return;
+            }
 
             ImGui.NewFrame();
             _frameBegun = true;


### PR DESCRIPTION
`ImGuiRenderer`'s constructor calls `ImGui.NewFrame()` as the last step of construction, which locks the renderer into an open frame immediately. ImGui's contract requires several IO settings to be configured *before* the first `NewFrame` call. The most visible casualty is `ImGuiConfigFlags.DockingEnable`, which silently drops with the assertion "Please set DockingEnable before the first call to NewFrame()! Otherwise you will lose your .ini settings!". Custom fonts loaded via `ImGui.GetIO().Fonts.AddFontFromFileTTF` and various backend flags fall in the same bucket. Upstream Veldrid has the same wart.

The constructors now accept an optional `bool autoInit = true` parameter. The default preserves current behavior: the first frame opens during construction, so existing callers are unaffected. Passing `autoInit: false` defers the first `NewFrame` so the caller can configure `ImGui.GetIO()` first, then complete setup through the new public `Initialize()` method.

```csharp
var renderer = new ImGuiRenderer(gd, output, w, h, ColorSpaceHandling.Linear, autoInit: false);

ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.DockingEnable;
ImGui.GetIO().Fonts.AddFontFromFileTTF(path, sizePx);
renderer.RecreateFontDeviceTexture();

renderer.Initialize();
```

`Initialize()` is idempotent (no-op if a frame is already in progress), so accidentally calling it when `autoInit: true` is harmless.

Closes #28.