### PR TITLE
[Core] Fix TextureViewDescription range constructor ignoring requested format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `[ImGui]` `ImGuiRenderer` now accepts an `autoInit: false` constructor option and exposes a public `Initialize()` method, so callers can configure `ImGui.GetIO()` (docking flags, custom fonts, etc.) before the first ImGui frame is opened.
 
+### Fixed
+
+- [Core] `TextureViewDescription`'s range-and-format constructor ignoring its format argument and using the target texture's format instead.
+
 ## [1.0.0] - 2026-04-25
 
 First release of NeoVeldrid. A maintained, drop-in replacement for [Veldrid](https://github.com/mellinoe/veldrid) with every native binding replaced by [Silk.NET](https://github.com/dotnet/Silk.NET). If you have a Veldrid project today, migrating is roughly a 5 minute find-and-replace. See the [Migration Guide](docs/articles/prologue/migration.md) for the exact steps.

--- a/src/NeoVeldrid/TextureViewDescription.cs
+++ b/src/NeoVeldrid/TextureViewDescription.cs
@@ -109,7 +109,7 @@ namespace NeoVeldrid
             MipLevels = mipLevels;
             BaseArrayLayer = baseArrayLayer;
             ArrayLayers = arrayLayers;
-            Format = target.Format;
+            Format = format;
         }
 
         /// <summary>


### PR DESCRIPTION
Long-standing upstream Veldrid bug. One of `TextureViewDescription`'s constructors takes an explicit `format` but stores the target's format instead:

```csharp
public TextureViewDescription(Texture target, PixelFormat format, uint baseMipLevel, uint mipLevels, uint baseArrayLayer, uint arrayLayers)
{
    ...
    Format = target.Format;   // should be `format`
}
```

So views created through it to reinterpret a texture's format (e.g. `UNorm` as `_SRgb`) silently come back with the wrong format. One-word fix: use `format`.

Ported from TechPizza's veldrid2 fork: [`f48dbc1`](https://github.com/veldrid2/veldrid2/commit/f48dbc16d83af9c86560c43d3e481bba77c930a9).
