### PR TITLE
Mark non-mutating struct members 'readonly' (IDE0251)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,5 +18,9 @@ indent_size = 2
 [*.cs]
 dotnet_diagnostic.CS1574.severity = error
 
+# IDE0251: Member can be made 'readonly'.
+csharp_style_prefer_readonly_struct_member = true
+dotnet_diagnostic.IDE0251.severity = error
+
 [*.md]
 trim_trailing_whitespace = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 
 - [Vulkan] Replaced the internal `StackList` stack-buffer helper with `stackalloc`.
+- Marked all non-mutating struct members `readonly` across the codebase.
 
 ## [1.0.0] - 2026-04-25
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,8 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- CS1591: Missing XML comment for publicly visible type (enforce in 1.0.1) -->
         <NoWarn>$(NoWarn);1591</NoWarn>
+        <!-- Run IDExxxx code-style analyzers at build time, not just in the IDE. -->
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     </PropertyGroup>
 
     <!-- NuGet package metadata -->

--- a/samples/AssetProcessor/AssimpProcessor.cs
+++ b/samples/AssetProcessor/AssimpProcessor.cs
@@ -324,19 +324,19 @@ namespace AssetProcessor
                 _vertexSize = vertexSize;
             }
 
-            public void WriteVertexElement<T>(int vertex, int elementOffset, ref T data)
+            public readonly void WriteVertexElement<T>(int vertex, int elementOffset, ref T data)
             {
                 byte* dst = _dataPtr + (_vertexSize * vertex) + elementOffset;
                 Unsafe.Copy(dst, ref data);
             }
 
-            public void WriteVertexElement<T>(int vertex, int elementOffset, T data)
+            public readonly void WriteVertexElement<T>(int vertex, int elementOffset, T data)
             {
                 byte* dst = _dataPtr + (_vertexSize * vertex) + elementOffset;
                 Unsafe.Copy(dst, ref data);
             }
 
-            public void FreeGCHandle()
+            public readonly void FreeGCHandle()
             {
                 _gch.Free();
             }

--- a/samples/Common/RawList.cs
+++ b/samples/Common/RawList.cs
@@ -265,8 +265,8 @@ namespace Common
                 _currentIndex = 0;
             }
 
-            public T Current => _list._items[_currentIndex];
-            object IEnumerator.Current => Current;
+            public readonly T Current => _list._items[_currentIndex];
+            readonly object IEnumerator.Current => Current;
 
             public bool MoveNext()
             {
@@ -284,7 +284,7 @@ namespace Common
                 _currentIndex = 0;
             }
 
-            public void Dispose() { }
+            public readonly void Dispose() { }
         }
     }
 }

--- a/samples/NeoDemo/RenderItemIndex.cs
+++ b/samples/NeoDemo/RenderItemIndex.cs
@@ -14,17 +14,17 @@ namespace NeoVeldrid.NeoDemo
             ItemIndex = itemIndex;
         }
 
-        public int CompareTo(object obj)
+        public readonly int CompareTo(object obj)
         {
             return ((IComparable)Key).CompareTo(obj);
         }
 
-        public int CompareTo(RenderItemIndex other)
+        public readonly int CompareTo(RenderItemIndex other)
         {
             return Key.CompareTo(other.Key);
         }
 
-        public override string ToString()
+        public override readonly string ToString()
         {
             return string.Format("Index:{0}, Key:{1}", ItemIndex, Key);
         }

--- a/samples/NeoDemo/RenderOrderKey.cs
+++ b/samples/NeoDemo/RenderOrderKey.cs
@@ -26,12 +26,12 @@ namespace NeoVeldrid.NeoDemo
                 cameraDistanceInt);
         }
 
-        public int CompareTo(RenderOrderKey other)
+        public readonly int CompareTo(RenderOrderKey other)
         {
             return Value.CompareTo(other.Value);
         }
 
-        int IComparable.CompareTo(object obj)
+        readonly int IComparable.CompareTo(object obj)
         {
             return Value.CompareTo(obj);
         }

--- a/samples/NeoDemo/RenderQueue.cs
+++ b/samples/NeoDemo/RenderQueue.cs
@@ -104,10 +104,10 @@ namespace NeoVeldrid.NeoDemo
                 _currentItem = null;
             }
 
-            public Renderable Current => _currentItem;
-            object IEnumerator.Current => _currentItem;
+            public readonly Renderable Current => _currentItem;
+            readonly object IEnumerator.Current => _currentItem;
 
-            public void Dispose()
+            public readonly void Dispose()
             {
             }
 

--- a/samples/NeoDemo/ShaderSetCacheKey.cs
+++ b/samples/NeoDemo/ShaderSetCacheKey.cs
@@ -13,12 +13,12 @@ namespace NeoVeldrid.NeoDemo
             Specializations = specializations;
         }
 
-        public bool Equals(ShaderSetCacheKey other)
+        public readonly bool Equals(ShaderSetCacheKey other)
         {
             return Name.Equals(other.Name) && ArraysEqual(Specializations, other.Specializations);
         }
 
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             int hash = Name.GetHashCode();
             foreach (var specConst in Specializations)
@@ -28,7 +28,7 @@ namespace NeoVeldrid.NeoDemo
             return hash;
         }
 
-        private bool ArraysEqual<T>(T[] a, T[] b) where T : IEquatable<T>
+        private readonly bool ArraysEqual<T>(T[] a, T[] b) where T : IEquatable<T>
         {
             if (a.Length != b.Length) { return false; }
 

--- a/samples/SampleBase/KtxFile.cs
+++ b/samples/SampleBase/KtxFile.cs
@@ -270,7 +270,7 @@ namespace SampleBase
         public readonly uint GlBaseInternalFormat;
         public readonly uint PixelWidth;
         private readonly uint _pixelHeight;
-        public uint PixelHeight => Math.Max(1, _pixelHeight);
+        public readonly uint PixelHeight => Math.Max(1, _pixelHeight);
         public readonly uint PixelDepth;
         public readonly uint NumberOfArrayElements;
         public readonly uint NumberOfFaces;

--- a/src/NeoVeldrid.Utilities/BoundingBox.cs
+++ b/src/NeoVeldrid.Utilities/BoundingBox.cs
@@ -15,7 +15,7 @@ namespace NeoVeldrid.Utilities
             Max = max;
         }
 
-        public ContainmentType Contains(ref BoundingBox other)
+        public readonly ContainmentType Contains(ref BoundingBox other)
         {
             if (Max.X < other.Min.X || Min.X > other.Max.X
                 || Max.Y < other.Min.Y || Min.Y > other.Max.Y
@@ -35,12 +35,12 @@ namespace NeoVeldrid.Utilities
             }
         }
 
-        public Vector3 GetCenter()
+        public readonly Vector3 GetCenter()
         {
             return (Max + Min) / 2f;
         }
 
-        public Vector3 GetDimensions()
+        public readonly Vector3 GetDimensions()
         {
             return Max - Min;
         }
@@ -144,22 +144,22 @@ namespace NeoVeldrid.Utilities
             return !first.Equals(second);
         }
 
-        public bool Equals(BoundingBox other)
+        public readonly bool Equals(BoundingBox other)
         {
             return Min == other.Min && Max == other.Max;
         }
 
-        public override string ToString()
+        public override readonly string ToString()
         {
             return string.Format("Min:{0}, Max:{1}", Min, Max);
         }
 
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is BoundingBox && ((BoundingBox)obj).Equals(this);
         }
 
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             int h1 = Min.GetHashCode();
             int h2 = Max.GetHashCode();
@@ -167,7 +167,7 @@ namespace NeoVeldrid.Utilities
             return ((int)shift5 + h1) ^ h2;
         }
 
-        public AlignedBoxCorners GetCorners()
+        public readonly AlignedBoxCorners GetCorners()
         {
             AlignedBoxCorners corners;
             corners.NearBottomLeft = new Vector3(Min.X, Min.Y, Max.Z);
@@ -183,7 +183,7 @@ namespace NeoVeldrid.Utilities
             return corners;
         }
 
-        public bool ContainsNaN()
+        public readonly bool ContainsNaN()
         {
             return float.IsNaN(Min.X) || float.IsNaN(Min.Y) || float.IsNaN(Min.Z)
                 || float.IsNaN(Max.X) || float.IsNaN(Max.Y) || float.IsNaN(Max.Z);

--- a/src/NeoVeldrid.Utilities/BoundingSphere.cs
+++ b/src/NeoVeldrid.Utilities/BoundingSphere.cs
@@ -15,12 +15,12 @@ namespace NeoVeldrid.Utilities
             Radius = radius;
         }
 
-        public override string ToString()
+        public override readonly string ToString()
         {
             return string.Format("Center:{0}, Radius:{1}", Center, Radius);
         }
 
-        public bool Contains(Vector3 point)
+        public readonly bool Contains(Vector3 point)
         {
             return (Center - point).LengthSquared() <= Radius * Radius;
         }

--- a/src/NeoVeldrid.Utilities/ObjParser.cs
+++ b/src/NeoVeldrid.Utilities/ObjParser.cs
@@ -516,7 +516,7 @@ namespace NeoVeldrid.Utilities
             /// </summary>
             public int TexCoordIndex;
 
-            public override string ToString()
+            public override readonly string ToString()
             {
                 return string.Format("Pos:{0}, Normal:{1}, TexCoord:{2}", PositionIndex, NormalIndex, TexCoordIndex);
             }

--- a/src/NeoVeldrid.Utilities/Ray.cs
+++ b/src/NeoVeldrid.Utilities/Ray.cs
@@ -13,12 +13,12 @@ namespace NeoVeldrid.Utilities
             Direction = direction;
         }
 
-        public bool Intersects(BoundingBox box)
+        public readonly bool Intersects(BoundingBox box)
         {
             return Intersects(ref box);
         }
 
-        public bool Intersects(ref BoundingBox box)
+        public readonly bool Intersects(ref BoundingBox box)
         {
             // http://www.scratchapixel.com/lessons/3d-basic-rendering/minimal-ray-tracer-rendering-simple-shapes/ray-box-intersection
 
@@ -79,7 +79,7 @@ namespace NeoVeldrid.Utilities
             return true;
         }
 
-        void Swap(ref float a, ref float b)
+        readonly void Swap(ref float a, ref float b)
         {
             var temp = a;
             a = b;
@@ -94,7 +94,7 @@ namespace NeoVeldrid.Utilities
         // Ray-Triangle Intersection, using the Möller–Trumbore intersection algorithm.
         // https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm
 
-        public bool Intersects(ref Vector3 V1, ref Vector3 V2, ref Vector3 V3, out float distance)
+        public readonly bool Intersects(ref Vector3 V1, ref Vector3 V2, ref Vector3 V3, out float distance)
         {
             const float EPSILON = 1E-6f;
 

--- a/src/NeoVeldrid.Utilities/StrideHelper.cs
+++ b/src/NeoVeldrid.Utilities/StrideHelper.cs
@@ -18,7 +18,7 @@ namespace NeoVeldrid.Utilities
             _stride = stride;
         }
 
-        public Enumerator GetEnumerator()
+        public readonly Enumerator GetEnumerator()
         {
             return new Enumerator(_basePtr, _count, _stride);
         }
@@ -38,7 +38,7 @@ namespace NeoVeldrid.Utilities
                 _currentItemIndex = -1;
             }
 
-            public T Current
+            public readonly T Current
             {
                 get
                 {
@@ -49,9 +49,9 @@ namespace NeoVeldrid.Utilities
                     }
                 }
             }
-            object IEnumerator.Current => Current;
+            readonly object IEnumerator.Current => Current;
 
-            public void Dispose()
+            public readonly void Dispose()
             {
             }
 

--- a/src/NeoVeldrid/BlendStateDescription.cs
+++ b/src/NeoVeldrid/BlendStateDescription.cs
@@ -96,7 +96,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements and all array elements are equal; false otherswise.</returns>
-        public bool Equals(BlendStateDescription other)
+        public readonly bool Equals(BlendStateDescription other)
         {
             return BlendFactor.Equals(other.BlendFactor)
                 && AlphaToCoverageEnabled.Equals(other.AlphaToCoverageEnabled)
@@ -107,7 +107,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(
                 BlendFactor.GetHashCode(),
@@ -115,7 +115,7 @@ namespace NeoVeldrid
                 HashHelper.Array(AttachmentStates));
         }
 
-        internal BlendStateDescription ShallowClone()
+        internal readonly BlendStateDescription ShallowClone()
         {
             BlendStateDescription result = this;
             result.AttachmentStates = Util.ShallowClone(result.AttachmentStates);

--- a/src/NeoVeldrid/BufferDescription.cs
+++ b/src/NeoVeldrid/BufferDescription.cs
@@ -85,7 +85,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(BufferDescription other)
+        public readonly bool Equals(BufferDescription other)
         {
             return SizeInBytes.Equals(other.SizeInBytes)
                 && Usage == other.Usage
@@ -97,7 +97,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(
                 SizeInBytes.GetHashCode(),

--- a/src/NeoVeldrid/CommandListDescription.cs
+++ b/src/NeoVeldrid/CommandListDescription.cs
@@ -12,7 +12,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(CommandListDescription other)
+        public readonly bool Equals(CommandListDescription other)
         {
             return true;
         }
@@ -21,7 +21,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return base.GetHashCode();
         }

--- a/src/NeoVeldrid/ComputePipelineDescription.cs
+++ b/src/NeoVeldrid/ComputePipelineDescription.cs
@@ -116,7 +116,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements and all array elements are equal; false otherswise.</returns>
-        public bool Equals(ComputePipelineDescription other)
+        public readonly bool Equals(ComputePipelineDescription other)
         {
             return ComputeShader.Equals(other.ComputeShader)
                 && Util.ArrayEquals(ResourceLayouts, other.ResourceLayouts)
@@ -129,7 +129,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(
                 ComputeShader.GetHashCode(),

--- a/src/NeoVeldrid/D3D11/D3D11Buffer.cs
+++ b/src/NeoVeldrid/D3D11/D3D11Buffer.cs
@@ -205,8 +205,8 @@ namespace NeoVeldrid.D3D11
                 Size = size;
             }
 
-            public bool Equals(OffsetSizePair other) => Offset.Equals(other.Offset) && Size.Equals(other.Size);
-            public override int GetHashCode() => HashHelper.Combine(Offset.GetHashCode(), Size.GetHashCode());
+            public readonly bool Equals(OffsetSizePair other) => Offset.Equals(other.Offset) && Size.Equals(other.Size);
+            public override readonly int GetHashCode() => HashHelper.Combine(Offset.GetHashCode(), Size.GetHashCode());
         }
     }
 }

--- a/src/NeoVeldrid/D3D11/D3D11CommandList.cs
+++ b/src/NeoVeldrid/D3D11/D3D11CommandList.cs
@@ -1579,7 +1579,7 @@ namespace NeoVeldrid.D3D11
             public readonly uint Offset;
             public readonly uint Size;
 
-            public bool IsFullRange => Offset == 0 && Size == Buffer.SizeInBytes;
+            public readonly bool IsFullRange => Offset == 0 && Size == Buffer.SizeInBytes;
 
             public D3D11BufferRange(D3D11Buffer buffer, uint offset, uint size)
             {
@@ -1588,7 +1588,7 @@ namespace NeoVeldrid.D3D11
                 Size = size;
             }
 
-            public bool Equals(D3D11BufferRange other)
+            public readonly bool Equals(D3D11BufferRange other)
             {
                 return Buffer == other.Buffer && Offset.Equals(other.Offset) && Size.Equals(other.Size);
             }

--- a/src/NeoVeldrid/D3D11/D3D11ResourceCache.cs
+++ b/src/NeoVeldrid/D3D11/D3D11ResourceCache.cs
@@ -327,12 +327,12 @@ namespace NeoVeldrid.D3D11
                 return new InputLayoutCacheKey { VertexLayouts = vertexLayouts };
             }
 
-            public bool Equals(InputLayoutCacheKey other)
+            public readonly bool Equals(InputLayoutCacheKey other)
             {
                 return Util.ArrayEqualsEquatable(VertexLayouts, other.VertexLayouts);
             }
 
-            public override int GetHashCode()
+            public override readonly int GetHashCode()
             {
                 return HashHelper.Array(VertexLayouts);
             }
@@ -349,13 +349,13 @@ namespace NeoVeldrid.D3D11
                 Multisampled = multisampled;
             }
 
-            public bool Equals(D3D11RasterizerStateCacheKey other)
+            public readonly bool Equals(D3D11RasterizerStateCacheKey other)
             {
                 return NeoVeldridDescription.Equals(other.NeoVeldridDescription)
                     && Multisampled.Equals(other.Multisampled);
             }
 
-            public override int GetHashCode()
+            public override readonly int GetHashCode()
             {
                 return HashHelper.Combine(NeoVeldridDescription.GetHashCode(), Multisampled.GetHashCode());
             }

--- a/src/NeoVeldrid/DepthStencilStateDescription.cs
+++ b/src/NeoVeldrid/DepthStencilStateDescription.cs
@@ -182,7 +182,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(DepthStencilStateDescription other)
+        public readonly bool Equals(DepthStencilStateDescription other)
         {
             return DepthTestEnabled.Equals(other.DepthTestEnabled)
                 && DepthWriteEnabled.Equals(other.DepthWriteEnabled)
@@ -199,7 +199,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(
                 DepthTestEnabled.GetHashCode(),

--- a/src/NeoVeldrid/DeviceBufferRange.cs
+++ b/src/NeoVeldrid/DeviceBufferRange.cs
@@ -40,7 +40,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(DeviceBufferRange other)
+        public readonly bool Equals(DeviceBufferRange other)
         {
             return Buffer == other.Buffer && Offset.Equals(other.Offset) && SizeInBytes.Equals(other.SizeInBytes);
         }
@@ -49,7 +49,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             int bufferHash = Buffer?.GetHashCode() ?? 0;
             return HashHelper.Combine(bufferHash, Offset.GetHashCode(), SizeInBytes.GetHashCode());

--- a/src/NeoVeldrid/FramebufferAttachmentDescription.cs
+++ b/src/NeoVeldrid/FramebufferAttachmentDescription.cs
@@ -76,7 +76,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements and all array elements are equal; false otherswise.</returns>
-        public bool Equals(FramebufferAttachmentDescription other)
+        public readonly bool Equals(FramebufferAttachmentDescription other)
         {
             return Target.Equals(other.Target) && ArrayLayer.Equals(other.ArrayLayer) && MipLevel.Equals(other.MipLevel);
         }
@@ -85,7 +85,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(Target.GetHashCode(), ArrayLayer.GetHashCode(), MipLevel.GetHashCode());
         }

--- a/src/NeoVeldrid/FramebufferDescription.cs
+++ b/src/NeoVeldrid/FramebufferDescription.cs
@@ -62,7 +62,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements and all array elements are equal; false otherswise.</returns>
-        public bool Equals(FramebufferDescription other)
+        public readonly bool Equals(FramebufferDescription other)
         {
             return Util.NullableEquals(DepthTarget, other.DepthTarget) && Util.ArrayEqualsEquatable(ColorTargets, other.ColorTargets);
         }

--- a/src/NeoVeldrid/GraphicsPipelineDescription.cs
+++ b/src/NeoVeldrid/GraphicsPipelineDescription.cs
@@ -152,7 +152,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements and all array elements are equal; false otherswise.</returns>
-        public bool Equals(GraphicsPipelineDescription other)
+        public readonly bool Equals(GraphicsPipelineDescription other)
         {
             return BlendState.Equals(other.BlendState)
                 && DepthStencilState.Equals(other.DepthStencilState)

--- a/src/NeoVeldrid/KeyEvent.cs
+++ b/src/NeoVeldrid/KeyEvent.cs
@@ -20,7 +20,7 @@
             Repeat = repeat;
         }
 
-        public override string ToString() => $"{Key} {(Down ? "Down" : "Up")} [{Modifiers}] (repeat={Repeat})";
+        public override readonly string ToString() => $"{Key} {(Down ? "Down" : "Up")} [{Modifiers}] (repeat={Repeat})";
     }
 
     public enum Key

--- a/src/NeoVeldrid/MappedResource.cs
+++ b/src/NeoVeldrid/MappedResource.cs
@@ -110,7 +110,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="index">The index of the value.</param>
         /// <returns>A reference to the value at the given index.</returns>
-        public ref T this[int index]
+        public readonly ref T this[int index]
         {
             get
             {
@@ -130,7 +130,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="index">The index of the value.</param>
         /// <returns>A reference to the value at the given index.</returns>
-        public ref T this[uint index]
+        public readonly ref T this[uint index]
         {
             get
             {
@@ -151,7 +151,7 @@ namespace NeoVeldrid
         /// <param name="x">The X coordinate.</param>
         /// <param name="y">The Y coordinate.</param>
         /// <returns>A reference to the value at the given coordinates.</returns>
-        public ref T this[int x, int y]
+        public readonly ref T this[int x, int y]
         {
             get
             {
@@ -166,7 +166,7 @@ namespace NeoVeldrid
         /// <param name="x">The X coordinate.</param>
         /// <param name="y">The Y coordinate.</param>
         /// <returns>A reference to the value at the given coordinates.</returns>
-        public ref T this[uint x, uint y]
+        public readonly ref T this[uint x, uint y]
         {
             get
             {
@@ -182,7 +182,7 @@ namespace NeoVeldrid
         /// <param name="y">The Y coordinate.</param>
         /// <param name="z">The Z coordinate.</param>
         /// <returns>A reference to the value at the given coordinates.</returns>
-        public ref T this[int x, int y, int z]
+        public readonly ref T this[int x, int y, int z]
         {
             get
             {
@@ -201,7 +201,7 @@ namespace NeoVeldrid
         /// <param name="y">The Y coordinate.</param>
         /// <param name="z">The Z coordinate.</param>
         /// <returns>A reference to the value at the given coordinates.</returns>
-        public ref T this[uint x, uint y, uint z]
+        public readonly ref T this[uint x, uint y, uint z]
         {
             get
             {

--- a/src/NeoVeldrid/MappedResourceCacheKey.cs
+++ b/src/NeoVeldrid/MappedResourceCacheKey.cs
@@ -13,13 +13,13 @@ namespace NeoVeldrid
             Subresource = subresource;
         }
 
-        public bool Equals(MappedResourceCacheKey other)
+        public readonly bool Equals(MappedResourceCacheKey other)
         {
             return Resource.Equals(other.Resource)
                 && Subresource.Equals(other.Subresource);
         }
 
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(Resource.GetHashCode(), Subresource.GetHashCode());
         }

--- a/src/NeoVeldrid/OpenGL/NoAllocEntryList/OpenGLNoAllocCommandEntryList.cs
+++ b/src/NeoVeldrid/OpenGL/NoAllocEntryList/OpenGLNoAllocCommandEntryList.cs
@@ -606,9 +606,9 @@ namespace NeoVeldrid.OpenGL.NoAllocEntryList
             public readonly byte* BasePtr;
 
             private uint _unusedStart;
-            public uint RemainingSize => (uint)_bytes.Length - _unusedStart;
+            public readonly uint RemainingSize => (uint)_bytes.Length - _unusedStart;
 
-            public uint TotalSize => (uint)_bytes.Length;
+            public readonly uint TotalSize => (uint)_bytes.Length;
 
             public bool Alloc(uint size, out void* ptr)
             {
@@ -638,7 +638,7 @@ namespace NeoVeldrid.OpenGL.NoAllocEntryList
                 return new EntryStorageBlock(DefaultStorageBlockSize);
             }
 
-            public void Free()
+            public readonly void Free()
             {
                 _gcHandle.Free();
             }
@@ -649,7 +649,7 @@ namespace NeoVeldrid.OpenGL.NoAllocEntryList
                 Util.ClearArray(_bytes);
             }
 
-            public bool Equals(EntryStorageBlock other)
+            public readonly bool Equals(EntryStorageBlock other)
             {
                 return _bytes == other._bytes;
             }
@@ -664,7 +664,7 @@ namespace NeoVeldrid.OpenGL.NoAllocEntryList
     {
         private readonly int _index;
 
-        public T Get(List<object> list) => (T)list[_index];
+        public readonly T Get(List<object> list) => (T)list[_index];
 
         public Tracked(List<object> list, T item)
         {

--- a/src/NeoVeldrid/OpenGL/OpenGLPipeline.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLPipeline.cs
@@ -469,22 +469,22 @@ namespace NeoVeldrid.OpenGL
             ShaderStorageBufferCount = (uint)storageBufferBindings.Count;
         }
 
-        public bool GetTextureBindingInfo(uint slot, out OpenGLTextureBindingSlotInfo binding)
+        public readonly bool GetTextureBindingInfo(uint slot, out OpenGLTextureBindingSlotInfo binding)
         {
             return _textureBindings.TryGetValue(slot, out binding);
         }
 
-        public bool GetSamplerBindingInfo(uint slot, out OpenGLSamplerBindingSlotInfo binding)
+        public readonly bool GetSamplerBindingInfo(uint slot, out OpenGLSamplerBindingSlotInfo binding)
         {
             return _samplerBindings.TryGetValue(slot, out binding);
         }
 
-        public bool GetUniformBindingForSlot(uint slot, out OpenGLUniformBinding binding)
+        public readonly bool GetUniformBindingForSlot(uint slot, out OpenGLUniformBinding binding)
         {
             return _uniformBindings.TryGetValue(slot, out binding);
         }
 
-        public bool GetStorageBufferBindingForSlot(uint slot, out OpenGLShaderStorageBinding binding)
+        public readonly bool GetStorageBufferBindingForSlot(uint slot, out OpenGLShaderStorageBinding binding)
         {
             return _storageBufferBindings.TryGetValue(slot, out binding);
         }

--- a/src/NeoVeldrid/OutputAttachmentDescription.cs
+++ b/src/NeoVeldrid/OutputAttachmentDescription.cs
@@ -26,7 +26,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(OutputAttachmentDescription other)
+        public readonly bool Equals(OutputAttachmentDescription other)
         {
             return Format == other.Format;
         }
@@ -35,7 +35,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return (int)Format;
         }

--- a/src/NeoVeldrid/OutputDescription.cs
+++ b/src/NeoVeldrid/OutputDescription.cs
@@ -73,7 +73,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements and all array elements are equal; false otherswise.</returns>
-        public bool Equals(OutputDescription other)
+        public readonly bool Equals(OutputDescription other)
         {
             return DepthAttachment.GetValueOrDefault().Equals(other.DepthAttachment.GetValueOrDefault())
                 && Util.ArrayEqualsEquatable(ColorAttachments, other.ColorAttachments)

--- a/src/NeoVeldrid/PixelFormatProperties.cs
+++ b/src/NeoVeldrid/PixelFormatProperties.cs
@@ -35,7 +35,7 @@
         /// </summary>
         /// <param name="count">The <see cref="TextureSampleCount"/> to query.</param>
         /// <returns>True if the sample count is supported; false otherwise.</returns>
-        public bool IsSampleCountSupported(TextureSampleCount count)
+        public readonly bool IsSampleCountSupported(TextureSampleCount count)
         {
             int bit = (int)count;
             return (_sampleCounts & (1 << bit)) != 0;

--- a/src/NeoVeldrid/Point.cs
+++ b/src/NeoVeldrid/Point.cs
@@ -15,14 +15,14 @@ namespace NeoVeldrid
             Y = y;
         }
 
-        public bool Equals(Point other) => X.Equals(other.X) && Y.Equals(other.Y);
-        public override bool Equals(object obj) => obj is Point p && Equals(p);
-        public override int GetHashCode() => HashHelper.Combine(X.GetHashCode(), Y.GetHashCode());
-        public override string ToString() => $"({X}, {Y})";
+        public readonly bool Equals(Point other) => X.Equals(other.X) && Y.Equals(other.Y);
+        public override readonly bool Equals(object obj) => obj is Point p && Equals(p);
+        public override readonly int GetHashCode() => HashHelper.Combine(X.GetHashCode(), Y.GetHashCode());
+        public override readonly string ToString() => $"({X}, {Y})";
 
         public static bool operator ==(Point left, Point right) => left.Equals(right);
         public static bool operator !=(Point left, Point right) => !left.Equals(right);
 
-        private string DebuggerDisplayString => ToString();
+        private readonly string DebuggerDisplayString => ToString();
     }
 }

--- a/src/NeoVeldrid/RasterizerStateDescription.cs
+++ b/src/NeoVeldrid/RasterizerStateDescription.cs
@@ -93,7 +93,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(RasterizerStateDescription other)
+        public readonly bool Equals(RasterizerStateDescription other)
         {
             return CullMode == other.CullMode
                 && FillMode == other.FillMode
@@ -106,7 +106,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(
                 (int)CullMode,

--- a/src/NeoVeldrid/Rectangle.cs
+++ b/src/NeoVeldrid/Rectangle.cs
@@ -29,26 +29,26 @@ namespace NeoVeldrid
             Height = size.Y;
         }
 
-        public int Left => X;
-        public int Right => X + Width;
-        public int Top => Y;
-        public int Bottom => Y + Height;
+        public readonly int Left => X;
+        public readonly int Right => X + Width;
+        public readonly int Top => Y;
+        public readonly int Bottom => Y + Height;
 
-        public Vector2 Position => new Vector2(X, Y);
-        public Vector2 Size => new Vector2(Width, Height);
+        public readonly Vector2 Position => new Vector2(X, Y);
+        public readonly Vector2 Size => new Vector2(Width, Height);
 
-        public bool Contains(Point p) => Contains(p.X, p.Y);
-        public bool Contains(int x, int y)
+        public readonly bool Contains(Point p) => Contains(p.X, p.Y);
+        public readonly bool Contains(int x, int y)
         {
             return (X <= x && (X + Width) > x)
                 && (Y <= y && (Y + Height) > y);
         }
 
-        public bool Equals(Rectangle other) => X.Equals(other.X) && Y.Equals(other.Y) && Width.Equals(other.Width) && Height.Equals(other.Height);
+        public readonly bool Equals(Rectangle other) => X.Equals(other.X) && Y.Equals(other.Y) && Width.Equals(other.Width) && Height.Equals(other.Height);
 
-        public override bool Equals(object obj) => obj is Rectangle r && Equals(r);
+        public override readonly bool Equals(object obj) => obj is Rectangle r && Equals(r);
 
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(X.GetHashCode(), HashHelper.Combine(Y.GetHashCode(), HashHelper.Combine(Width.GetHashCode(), Height.GetHashCode())));
         }

--- a/src/NeoVeldrid/ResourceLayoutDescription.cs
+++ b/src/NeoVeldrid/ResourceLayoutDescription.cs
@@ -28,7 +28,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all array elements are equal; false otherswise.</returns>
-        public bool Equals(ResourceLayoutDescription other)
+        public readonly bool Equals(ResourceLayoutDescription other)
         {
             return Util.ArrayEqualsEquatable(Elements, other.Elements);
         }
@@ -37,7 +37,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Array(Elements);
         }

--- a/src/NeoVeldrid/ResourceLayoutElementDescription.cs
+++ b/src/NeoVeldrid/ResourceLayoutElementDescription.cs
@@ -62,7 +62,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(ResourceLayoutElementDescription other)
+        public readonly bool Equals(ResourceLayoutElementDescription other)
         {
             return Name == other.Name && Kind == other.Kind && Stages == other.Stages && Options == other.Options;
         }
@@ -71,7 +71,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(Name.GetHashCode(), (int)Kind, (int)Stages, (int)Options);
         }

--- a/src/NeoVeldrid/ResourceSetDescription.cs
+++ b/src/NeoVeldrid/ResourceSetDescription.cs
@@ -34,7 +34,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements and all array elements are equal; false otherswise.</returns>
-        public bool Equals(ResourceSetDescription other)
+        public readonly bool Equals(ResourceSetDescription other)
         {
             return Layout.Equals(other.Layout) && Util.ArrayEquals(BoundResources, other.BoundResources);
         }
@@ -43,7 +43,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(Layout.GetHashCode(), HashHelper.Array(BoundResources));
         }

--- a/src/NeoVeldrid/RgbaByte.cs
+++ b/src/NeoVeldrid/RgbaByte.cs
@@ -103,7 +103,7 @@ namespace NeoVeldrid
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(RgbaByte other)
+        public readonly bool Equals(RgbaByte other)
         {
             return R.Equals(other.R) && G.Equals(other.G) && B.Equals(other.B) && A.Equals(other.A);
         }
@@ -113,7 +113,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object is equal to the current object; otherwise, false.</returns>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is RgbaByte other && Equals(other);
         }
@@ -123,7 +123,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(R.GetHashCode(), G.GetHashCode(), B.GetHashCode(), A.GetHashCode());
         }
@@ -132,7 +132,7 @@ namespace NeoVeldrid
         /// Returns a string representation of this color.
         /// </summary>
         /// <returns></returns>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return string.Format("R:{0}, G:{1}, B:{2}, A:{3}", R, G, B, A);
         }

--- a/src/NeoVeldrid/RgbaFloat.cs
+++ b/src/NeoVeldrid/RgbaFloat.cs
@@ -14,19 +14,19 @@ namespace NeoVeldrid
         /// <summary>
         /// The red component.
         /// </summary>
-        public float R => _channels.X;
+        public readonly float R => _channels.X;
         /// <summary>
         /// The green component.
         /// </summary>
-        public float G => _channels.Y;
+        public readonly float G => _channels.Y;
         /// <summary>
         /// The blue component.
         /// </summary>
-        public float B => _channels.Z;
+        public readonly float B => _channels.Z;
         /// <summary>
         /// The alpha component.
         /// </summary>
-        public float A => _channels.W;
+        public readonly float A => _channels.W;
 
         /// <summary>
         /// Constructs a new RgbaFloat from the given components.
@@ -116,7 +116,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Vector4 ToVector4()
+        public readonly Vector4 ToVector4()
         {
             return _channels;
         }
@@ -127,7 +127,7 @@ namespace NeoVeldrid
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(RgbaFloat other)
+        public readonly bool Equals(RgbaFloat other)
         {
             return _channels.Equals(other._channels);
         }
@@ -137,7 +137,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object is equal to the current object; otherwise, false.</returns>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is RgbaFloat other && Equals(other);
         }
@@ -147,7 +147,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(R.GetHashCode(), G.GetHashCode(), B.GetHashCode(), A.GetHashCode());
         }
@@ -156,7 +156,7 @@ namespace NeoVeldrid
         /// Returns a string representation of this color.
         /// </summary>
         /// <returns></returns>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return string.Format("R:{0}, G:{1}, B:{2}, A:{3}", R, G, B, A);
         }

--- a/src/NeoVeldrid/SamplerDescription.cs
+++ b/src/NeoVeldrid/SamplerDescription.cs
@@ -165,7 +165,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(SamplerDescription other)
+        public readonly bool Equals(SamplerDescription other)
         {
             return AddressModeU == other.AddressModeU
                 && AddressModeV == other.AddressModeV

--- a/src/NeoVeldrid/ShaderDescription.cs
+++ b/src/NeoVeldrid/ShaderDescription.cs
@@ -66,7 +66,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements and if array instances are equal; false otherswise.</returns>
-        public bool Equals(ShaderDescription other)
+        public readonly bool Equals(ShaderDescription other)
         {
             return Stage == other.Stage
                 && ShaderBytes == other.ShaderBytes
@@ -78,7 +78,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(
                 (int)Stage,

--- a/src/NeoVeldrid/ShaderSetDescription.cs
+++ b/src/NeoVeldrid/ShaderSetDescription.cs
@@ -69,7 +69,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all array elements are equal; false otherswise.</returns>
-        public bool Equals(ShaderSetDescription other)
+        public readonly bool Equals(ShaderSetDescription other)
         {
             return Util.ArrayEqualsEquatable(VertexLayouts, other.VertexLayouts)
                 && Util.ArrayEquals(Shaders, other.Shaders)
@@ -80,7 +80,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(
                 HashHelper.Array(VertexLayouts),

--- a/src/NeoVeldrid/SmallFixedOrDynamicArray.cs
+++ b/src/NeoVeldrid/SmallFixedOrDynamicArray.cs
@@ -33,7 +33,7 @@ namespace NeoVeldrid
             Count = count;
         }
 
-        public void Dispose()
+        public readonly void Dispose()
         {
             if (Data != null) { ArrayPool<uint>.Shared.Return(Data); }
         }

--- a/src/NeoVeldrid/SpecializationConstant.cs
+++ b/src/NeoVeldrid/SpecializationConstant.cs
@@ -104,7 +104,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(SpecializationConstant other)
+        public readonly bool Equals(SpecializationConstant other)
         {
             return ID.Equals(other.ID) && Type == other.Type && Data.Equals(other.Data);
         }
@@ -113,7 +113,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(ID.GetHashCode(), (int)Type, Data.GetHashCode());
         }

--- a/src/NeoVeldrid/StencilBehaviorDescription.cs
+++ b/src/NeoVeldrid/StencilBehaviorDescription.cs
@@ -48,7 +48,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(StencilBehaviorDescription other)
+        public readonly bool Equals(StencilBehaviorDescription other)
         {
             return Fail == other.Fail && Pass == other.Pass && DepthFail == other.DepthFail && Comparison == other.Comparison;
         }
@@ -57,7 +57,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine((int)Fail, (int)Pass, (int)DepthFail, (int)Comparison);
         }

--- a/src/NeoVeldrid/SwapchainDescription.cs
+++ b/src/NeoVeldrid/SwapchainDescription.cs
@@ -96,7 +96,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(SwapchainDescription other)
+        public readonly bool Equals(SwapchainDescription other)
         {
             return Source.Equals(other.Source)
                 && Width.Equals(other.Width)

--- a/src/NeoVeldrid/TextureDescription.cs
+++ b/src/NeoVeldrid/TextureDescription.cs
@@ -265,7 +265,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(TextureDescription other)
+        public readonly bool Equals(TextureDescription other)
         {
             return Width.Equals(other.Width)
                 && Height.Equals(other.Height)
@@ -282,7 +282,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(
                 Width.GetHashCode(),

--- a/src/NeoVeldrid/TextureViewDescription.cs
+++ b/src/NeoVeldrid/TextureViewDescription.cs
@@ -117,7 +117,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(TextureViewDescription other)
+        public readonly bool Equals(TextureViewDescription other)
         {
             return Target.Equals(other.Target)
                 && BaseMipLevel.Equals(other.BaseMipLevel)
@@ -131,7 +131,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(
                 Target.GetHashCode(),

--- a/src/NeoVeldrid/VertexElementDescription.cs
+++ b/src/NeoVeldrid/VertexElementDescription.cs
@@ -78,7 +78,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(VertexElementDescription other)
+        public readonly bool Equals(VertexElementDescription other)
         {
             return Name.Equals(other.Name)
                 && Format == other.Format
@@ -90,7 +90,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(
                 Name.GetHashCode(),

--- a/src/NeoVeldrid/VertexLayoutDescription.cs
+++ b/src/NeoVeldrid/VertexLayoutDescription.cs
@@ -84,7 +84,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements and all array elements are equal; false otherswise.</returns>
-        public bool Equals(VertexLayoutDescription other)
+        public readonly bool Equals(VertexLayoutDescription other)
         {
             return Stride.Equals(other.Stride)
                 && Util.ArrayEqualsEquatable(Elements, other.Elements)
@@ -95,7 +95,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(Stride.GetHashCode(), HashHelper.Array(Elements), InstanceStepRate.GetHashCode());
         }

--- a/src/NeoVeldrid/Viewport.cs
+++ b/src/NeoVeldrid/Viewport.cs
@@ -56,7 +56,7 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="other">The instance to compare to.</param>
         /// <returns>True if all elements are equal; false otherswise.</returns>
-        public bool Equals(Viewport other)
+        public readonly bool Equals(Viewport other)
         {
             return X.Equals(other.X) && Y.Equals(other.Y)
                 && Width.Equals(other.Width) && Height.Equals(other.Height)
@@ -67,7 +67,7 @@ namespace NeoVeldrid
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             return HashHelper.Combine(
                 X.GetHashCode(),

--- a/src/NeoVeldrid/Vk/FixedArray.cs
+++ b/src/NeoVeldrid/Vk/FixedArray.cs
@@ -10,7 +10,7 @@
 
         public FixedArray2(T first, T second) { First = first; Second = second; }
 
-        public uint Count => 2;
+        public readonly uint Count => 2;
     }
 
     internal struct FixedArray3<T> where T : struct
@@ -21,7 +21,7 @@
 
         public FixedArray3(T first, T second, T third) { First = first; Second = second; Third = third; }
 
-        public uint Count => 3;
+        public readonly uint Count => 3;
     }
 
     internal struct FixedArray4<T> where T : struct
@@ -33,7 +33,7 @@
 
         public FixedArray4(T first, T second, T third, T fourth) { First = first; Second = second; Third = third; Fourth = fourth; }
 
-        public uint Count => 4;
+        public readonly uint Count => 4;
     }
 
     internal struct FixedArray5<T> where T : struct
@@ -46,7 +46,7 @@
 
         public FixedArray5(T first, T second, T third, T fourth, T fifth) { First = first; Second = second; Third = third; Fourth = fourth; Fifth = fifth; }
 
-        public uint Count => 5;
+        public readonly uint Count => 5;
     }
 
     internal struct FixedArray6<T> where T : struct
@@ -60,6 +60,6 @@
 
         public FixedArray6(T first, T second, T third, T fourth, T fifth, T sixth) { First = first; Second = second; Third = third; Fourth = fourth; Fifth = fifth; Sixth = sixth; }
 
-        public uint Count => 6;
+        public readonly uint Count => 6;
     }
 }

--- a/src/NeoVeldrid/Vk/VkDeviceMemoryManager.cs
+++ b/src/NeoVeldrid/Vk/VkDeviceMemoryManager.cs
@@ -494,9 +494,9 @@ namespace NeoVeldrid.Vk
         public ulong Offset;
         public ulong Size;
 
-        public void* BlockMappedPointer => ((byte*)BaseMappedPointer) + Offset;
-        public bool IsPersistentMapped => BaseMappedPointer != null;
-        public ulong End => Offset + Size;
+        public readonly void* BlockMappedPointer => ((byte*)BaseMappedPointer) + Offset;
+        public readonly bool IsPersistentMapped => BaseMappedPointer != null;
+        public readonly ulong End => Offset + Size;
 
         public VkMemoryBlock(
             DeviceMemory memory,
@@ -514,7 +514,7 @@ namespace NeoVeldrid.Vk
             DedicatedAllocation = dedicatedAllocation;
         }
 
-        public bool Equals(VkMemoryBlock other)
+        public readonly bool Equals(VkMemoryBlock other)
         {
             return DeviceMemory.Handle.Equals(other.DeviceMemory.Handle)
                 && Offset.Equals(other.Offset)

--- a/src/NeoVeldrid/Vk/VkVersion.cs
+++ b/src/NeoVeldrid/Vk/VkVersion.cs
@@ -9,11 +9,11 @@
             value = major << 22 | minor << 12 | patch;
         }
 
-        public uint Major => value >> 22;
+        public readonly uint Major => value >> 22;
 
-        public uint Minor => (value >> 12) & 0x3ff;
+        public readonly uint Minor => (value >> 12) & 0x3ff;
 
-        public uint Patch => (value >> 22) & 0xfff;
+        public readonly uint Patch => (value >> 22) & 0xfff;
 
         public static implicit operator uint(VkVersion version)
         {

--- a/tests/NeoVeldrid.Tests/TextureDataReaderWriter.cs
+++ b/tests/NeoVeldrid.Tests/TextureDataReaderWriter.cs
@@ -127,7 +127,7 @@ namespace NeoVeldrid.Tests
             A = a;
         }
 
-        public bool Equals(WidePixel other)
+        public readonly bool Equals(WidePixel other)
         {
             return R.HasValue == other.R.HasValue && R.GetValueOrDefault().Equals(other.R.GetValueOrDefault())
                 && G.HasValue == other.G.HasValue && G.GetValueOrDefault().Equals(other.G.GetValueOrDefault())
@@ -135,7 +135,7 @@ namespace NeoVeldrid.Tests
                 && A.HasValue == other.A.HasValue && A.GetValueOrDefault().Equals(other.A.GetValueOrDefault());
         }
 
-        public override string ToString()
+        public override readonly string ToString()
         {
             return $"{R}, {G}, {B}, {A}";
         }


### PR DESCRIPTION
Enables the IDE0251 analyzer ("Member can be made 'readonly'") as a build error and applies it across the codebase, so non-mutating struct instance members carry the `readonly` modifier.

## Why

`readonly` on a struct member is a contract that the member doesn't mutate `this`. For the public value types (the `*Description` structs, `RgbaFloat`, and friends), it lets a consumer's compiler skip the defensive copy when they invoke a member through an `in` parameter or a `readonly` field. Only we can grant that, since they compile against the shipped assembly. It also makes intent explicit.

## What changed

- `.editorconfig`: IDE0251 set to `error`.
- `Directory.Build.props`: `EnforceCodeStyleInBuild` so the rule runs at build time, not only in the IDE. New non-`readonly`-able members now fail the build.
- The `readonly` modifier added to non-mutating struct members across core, all backends, Utilities, samples, and tests (applied with `dotnet format`).

No behavior change. `readonly` is metadata plus a compiler hint, and it's source-compatible.