### PR TITLE
[SDL2] Fix Sdl2WindowRegistry racing the event-pump thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Core] `TextureViewDescription`'s range-and-format constructor ignoring its format argument and using the target texture's format instead.
+- [SDL2] `Sdl2WindowRegistry` reading its window dictionary without a lock, racing the SDL event-pump thread.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Core] `TextureViewDescription`'s range-and-format constructor ignoring its format argument and using the target texture's format instead.
-- [SDL2] `Sdl2WindowRegistry` reading its window dictionary without a lock, racing the SDL event-pump thread.
+- [SDL2] Fix `Sdl2WindowRegistry` race condition in the event-pump thread.
 
 ### Internal
 

--- a/src/NeoVeldrid.SDL2/Sdl2WindowRegistry.cs
+++ b/src/NeoVeldrid.SDL2/Sdl2WindowRegistry.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Silk.NET.SDL;
 
 namespace NeoVeldrid.Sdl2
@@ -8,21 +9,33 @@ namespace NeoVeldrid.Sdl2
     internal static class Sdl2WindowRegistry
     {
         public static readonly object Lock = new object();
-        private static readonly Dictionary<uint, Sdl2Window> _eventsByWindowID
-            = new Dictionary<uint, Sdl2Window>();
-        private static bool _firstInit;
+
+        private static readonly Dictionary<uint, Sdl2Window> _eventsByWindowID = new();
+
+        // Subscribe once at type init, outside any lock. The event pump holds Sdl2Events' lock while
+        // calling ProcessWindowEvent, which takes Lock below. Subscribing under Lock would create the
+        // reverse acquisition order (Lock, then Sdl2Events' lock) and risk a deadlock.
+        static Sdl2WindowRegistry()
+        {
+            Sdl2Events.Subscribe(ProcessWindowEvent);
+        }
 
         public static void RegisterWindow(Sdl2Window window)
         {
+            if (window.WindowID == 0)
+            {
+                throw new InvalidOperationException("SDL window creation failed: " + GetSdlError());
+            }
+
             lock (Lock)
             {
                 _eventsByWindowID.Add(window.WindowID, window);
-                if (!_firstInit)
-                {
-                    _firstInit = true;
-                    Sdl2Events.Subscribe(ProcessWindowEvent);
-                }
             }
+        }
+
+        private static unsafe string GetSdlError()
+        {
+            return Marshal.PtrToStringUTF8((nint)Sdl2Window.SdlInstance.GetError()) ?? "unknown SDL error";
         }
 
         public static void RemoveWindow(Sdl2Window window)
@@ -69,9 +82,15 @@ namespace NeoVeldrid.Sdl2
                     break;
             }
 
-            if (handled && _eventsByWindowID.TryGetValue(windowID, out Sdl2Window window))
+            if (handled)
             {
-                window.AddEvent(ev);
+                lock (Lock)
+                {
+                    if (_eventsByWindowID.TryGetValue(windowID, out Sdl2Window window))
+                    {
+                        window.AddEvent(ev);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
`Sdl2WindowRegistry` read its window dictionary without a lock from the SDL event-pump thread, while `RegisterWindow`/`RemoveWindow` wrote it under `Lock`. Concurrent `Dictionary` access from the pump thread and a window create/destroy thread can corrupt it or throw. This affects windows created with `threadedProcessing: true` (each runs its own event pump).

## What changed

- `ProcessWindowEvent` now takes `Lock`, the same object the writers use, around the dictionary read.
- `RegisterWindow` rejects a failed window (`WindowID == 0`) and surfaces the SDL error instead of registering a broken entry.
- `Subscribe` moved to a static constructor so it runs once, outside any lock. Subscribing under `Lock` would invert the acquisition order against the pump (which holds the events lock and then needs `Lock`), risking a deadlock.

## Credit

Ported from TechPizza's veldrid2 fork: [`9ae7479`](https://github.com/veldrid2/veldrid2/commit/9ae747900975b274ce27630d9d36b7b4c2f427fa). One correction: their version locked the read on the dictionary object itself rather than on the shared `Lock`, so it did not actually synchronize with the writers. This locks the same object the writers use.