### PR TITLE
[Core] Fix GraphicsDevice.Dispose() crashing or hanging when called more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+In addition to SemVer defaults, an "Internal" section is used to denote changes that are not user facing but improve the maintenance state of the package.
+
 ## [Unreleased]
 
 ### Added
@@ -14,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Core] `TextureViewDescription`'s range-and-format constructor ignoring its format argument and using the target texture's format instead.
+- [Core] `GraphicsDevice.Dispose()` deadlocking or crashing when called more than once.
 - [SDL2] Fix `Sdl2WindowRegistry` race condition in the event-pump thread.
 
 ### Internal

--- a/src/NeoVeldrid/GraphicsDevice.cs
+++ b/src/NeoVeldrid/GraphicsDevice.cs
@@ -14,6 +14,7 @@ namespace NeoVeldrid
         private readonly object _deferredDisposalLock = new object();
         private readonly List<IDisposable> _disposables = new List<IDisposable>();
         private Sampler _aniso4xSampler;
+        private bool _disposed;
 
         internal GraphicsDevice() { }
 
@@ -851,6 +852,12 @@ namespace NeoVeldrid
         /// </summary>
         public void Dispose()
         {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+
             WaitForIdle();
             PointSampler.Dispose();
             LinearSampler.Dispose();

--- a/tests/NeoVeldrid.Tests/DisposalTests.RegressionTests.cs
+++ b/tests/NeoVeldrid.Tests/DisposalTests.RegressionTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading.Tasks;
+using NeoVeldrid.Sdl2;
+using Xunit;
+
+namespace NeoVeldrid.Tests
+{
+    // Regression tests for disposal bugs that have been fixed in NeoVeldrid. Each test guards a
+    // specific past bug and is not part of the general disposal coverage in DisposalTests.cs.
+    //
+    // Unlike DisposalTestBase<T>, these tests do not use the shared fixture device, because they
+    // need to dispose the GraphicsDevice itself: the fixture teardown calls WaitForIdle() before
+    // its own Dispose(), which would hit the same hang the test below exercises. Each test creates
+    // and owns a throwaway device instead.
+    public abstract class DeviceDisposalRegressionTests<T> where T : GraphicsDeviceCreator
+    {
+        // GraphicsDevice.Dispose() used to re-run PlatformDispose() on every call. On the OpenGL
+        // backend the second call posted a FlushAndFinish work item to the execution thread, but
+        // that thread had already terminated during the first dispose, so the post blocked forever.
+        // IDisposable requires Dispose to be safe to call more than once; this verifies the second
+        // call returns promptly instead of deadlocking. The timeout turns a regression into a test
+        // failure rather than a hung run.
+        [Fact(Timeout = 10000)]
+        public Task Dispose_Twice_DoesNotHang()
+        {
+            // The work runs on a separate thread so the timeout can fire even if the second
+            // Dispose() blocks: a synchronous deadlock would freeze the very thread the test
+            // runner waits on, leaving nothing to time out.
+            return Task.Run(() =>
+            {
+                Activator.CreateInstance<T>().CreateGraphicsDevice(out Sdl2Window window, out GraphicsDevice gd);
+                gd.Dispose();
+                gd.Dispose();
+                window?.Close();
+            });
+        }
+    }
+
+#if TEST_VULKAN
+    [Trait("Backend", "Vulkan")]
+    public class VulkanDeviceDisposalRegressionTests : DeviceDisposalRegressionTests<VulkanDeviceCreator> { }
+#endif
+#if TEST_D3D11
+    [Trait("Backend", "D3D11")]
+    public class D3D11DeviceDisposalRegressionTests : DeviceDisposalRegressionTests<D3D11DeviceCreator> { }
+#endif
+#if TEST_OPENGL
+    [Trait("Backend", "OpenGL")]
+    public class OpenGLDeviceDisposalRegressionTests : DeviceDisposalRegressionTests<OpenGLDeviceCreator> { }
+#endif
+#if TEST_OPENGLES
+    [Trait("Backend", "OpenGLES")]
+    public class OpenGLESDeviceDisposalRegressionTests : DeviceDisposalRegressionTests<OpenGLESDeviceCreator> { }
+#endif
+}


### PR DESCRIPTION
`GraphicsDevice.Dispose()` had no idempotency guard, so calling it a second time re-ran the whole teardown. `IDisposable` requires `Dispose` to be safe to call more than once; instead the second call failed a different way on each backend:

- **OpenGL / OpenGL ES**: deadlock. The second dispose posts a flush work item to the GL execution thread, but that thread already terminated on the first dispose, so it waits forever on an event nothing will set. It hangs, so the existing `try/catch` around the flush can't help.
- **D3D11**: crash. In debug mode the device pointer is cleared on the first pass, so the second `Release()` dereferences null.
- **Vulkan**: undefined behavior, re-destroying the device and instance handles the first dispose already destroyed.

## What changed

A single `_disposed` guard at the top of the base `GraphicsDevice.Dispose()`. All three backends share that method (each implements only the `protected abstract PlatformDispose()` hook and none override the public `Dispose`), so one guard covers every backend.

## Credit

Ported from TechPizza's veldrid2 fork: [`4916bdd`](https://github.com/veldrid2/veldrid2/commit/4916bdd4a87a88dd6a041f2d6eb15efaf9e3c68d). Their fix guarded only the OpenGL backend with an `Interlocked.Exchange` on its execution thread. Putting the guard in the base `Dispose` instead fixes the contract where it lives and covers D3D11 and Vulkan too.
