### PR TITLE
[Core] Add GraphicsDevice.IsDisposed property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 ### Added
 
 - `[ImGui]` `ImGuiRenderer` now accepts an `autoInit: false` constructor option and exposes a public `Initialize()` method, so callers can configure `ImGui.GetIO()` (docking flags, custom fonts, etc.) before the first ImGui frame is opened.
+- [Core] `GraphicsDevice.IsDisposed` property, matching the `IsDisposed` already exposed by every device resource.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 ### Added
 
 - `[ImGui]` `ImGuiRenderer` now accepts an `autoInit: false` constructor option and exposes a public `Initialize()` method, so callers can configure `ImGui.GetIO()` (docking flags, custom fonts, etc.) before the first ImGui frame is opened.
-- [Core] `GraphicsDevice.IsDisposed` property, matching the `IsDisposed` already exposed by every device resource.
+- [Core] Added `GraphicsDevice.IsDisposed` property, matching the `IsDisposed` already exposed by every device resource.
 
 ### Fixed
 

--- a/src/NeoVeldrid/GraphicsDevice.cs
+++ b/src/NeoVeldrid/GraphicsDevice.cs
@@ -847,6 +847,11 @@ namespace NeoVeldrid
         }
 
         /// <summary>
+        /// A bool indicating whether this instance has been disposed.
+        /// </summary>
+        public bool IsDisposed => _disposed;
+
+        /// <summary>
         /// Frees unmanaged resources controlled by this device.
         /// All created child resources must be Disposed prior to calling this method.
         /// </summary>

--- a/tests/NeoVeldrid.Tests/DisposalTests.RegressionTests.cs
+++ b/tests/NeoVeldrid.Tests/DisposalTests.RegressionTests.cs
@@ -19,7 +19,8 @@ namespace NeoVeldrid.Tests
         // that thread had already terminated during the first dispose, so the post blocked forever.
         // IDisposable requires Dispose to be safe to call more than once; this verifies the second
         // call returns promptly instead of deadlocking. The timeout turns a regression into a test
-        // failure rather than a hung run.
+        // failure rather than a hung run. It also checks IsDisposed tracks the lifecycle: false
+        // while the device is live, true once disposed.
         [Fact(Timeout = 10000)]
         public Task Dispose_Twice_DoesNotHang()
         {
@@ -29,8 +30,10 @@ namespace NeoVeldrid.Tests
             return Task.Run(() =>
             {
                 Activator.CreateInstance<T>().CreateGraphicsDevice(out Sdl2Window window, out GraphicsDevice gd);
+                Assert.False(gd.IsDisposed);
                 gd.Dispose();
                 gd.Dispose();
+                Assert.True(gd.IsDisposed);
                 window?.Close();
             });
         }


### PR DESCRIPTION
Exposes `GraphicsDevice.IsDisposed`, closing the gap where every device resource reported its disposed state but the device itself did not.