### PR TITLE
[Core] Fix Texture.Dispose() racing concurrent default-view creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 - [Core] `TextureViewDescription`'s range-and-format constructor ignoring its format argument and using the target texture's format instead.
 - [Core] `GraphicsDevice.Dispose()` deadlocking or crashing when called more than once.
+- [Core] `Texture.Dispose()` racing concurrent creation of the texture's default view, which could free the device resource while it was still being used.
 - [SDL2] Fix `Sdl2WindowRegistry` race condition in the event-pump thread.
 
 ### Internal

--- a/src/NeoVeldrid/Texture.cs
+++ b/src/NeoVeldrid/Texture.cs
@@ -96,9 +96,11 @@ namespace NeoVeldrid
             lock (_fullTextureViewLock)
             {
                 _fullTextureView?.Dispose();
-            }
 
-            DisposeCore();
+                // Held through DisposeCore so a concurrent GetFullTextureView can't
+                // build a view on a texture whose device resource is being freed.
+                DisposeCore();
+            }
         }
 
         private protected abstract void DisposeCore();


### PR DESCRIPTION
`Texture.Dispose()` disposed the cached full-texture-view inside `_fullTextureViewLock`, but then called the backend `DisposeCore()` (which frees the native device resource) *outside* that lock. `GetFullTextureView()` lazily creates the view *inside* the same lock, and that view is built whenever a `Texture` is bound directly as a resource. So a thread creating the view could take the lock in the window after it was released and build a `TextureView` on a texture whose device resource was already being torn down: a use-after-free.

## What changed

Moved `DisposeCore()` inside the `_fullTextureViewLock` block, making the device-resource teardown atomic with respect to view creation. A thread in `GetFullTextureView()` now either runs fully before disposal or observes the disposed texture; it can no longer build a view on one mid-disposal.

## Credit

Ported from TechPizza's veldrid2 fork: [`5b8ded1`](https://github.com/veldrid2/veldrid2/commit/5b8ded157f9d39cf9556ec769fba9c2ee4d990b6). That commit also made `Dispose` non-virtual; this keeps it `virtual` to avoid a public API break and takes only the lock move.