### PR TITLE
[Vulkan] Fix CommandList staging-info race between submit and fence completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 - [Core] `GraphicsDevice.Dispose()` deadlocking or crashing when called more than once.
 - [Core] `Texture.Dispose()` racing concurrent creation of the texture's default view, which could free the device resource while it was still being used.
 - [SDL2] Fix `Sdl2WindowRegistry` race condition in the event-pump thread.
+- [Vulkan] `CommandList` staging-resource tracking racing between submit and fence-completion, which could corrupt the tracking dictionary or leak staging resources.
 
 ### Internal
 

--- a/src/NeoVeldrid/Vk/VkCommandList.cs
+++ b/src/NeoVeldrid/Vk/VkCommandList.cs
@@ -111,13 +111,15 @@ namespace NeoVeldrid.Vk
                 rrc.Increment();
             }
 
-            _submittedStagingInfos.Add(cb, _currentStagingInfo);
+            lock (_stagingLock)
+            {
+                _submittedStagingInfos.Add(cb, _currentStagingInfo);
+            }
             _currentStagingInfo = null;
         }
 
         public void CommandBufferCompleted(CommandBuffer completedCB)
         {
-
             lock (_commandBufferListLock)
             {
                 for (int i = 0; i < _submittedCommandBuffers.Count; i++)
@@ -134,10 +136,9 @@ namespace NeoVeldrid.Vk
 
             lock (_stagingLock)
             {
-                if (_submittedStagingInfos.TryGetValue(completedCB, out StagingResourceInfo info))
+                if (_submittedStagingInfos.Remove(completedCB, out StagingResourceInfo info))
                 {
                     RecycleStagingInfo(info);
-                    _submittedStagingInfos.Remove(completedCB);
                 }
             }
 


### PR DESCRIPTION
`VkCommandList.CommandBufferSubmitted` added the submitted command buffer's staging info to `_submittedStagingInfos` with no lock, while `CommandBufferCompleted` reads and removes from that same dictionary under `_stagingLock` on the fence-completion thread. Resubmitting a command list on one thread while a prior submission completes on another is then two threads mutating one `Dictionary` at once. That can corrupt its internal state or drop entries, which leaks the staging buffers and resource ref-counts those entries were tracking.

## What changed

- The `_submittedStagingInfos.Add(...)` in `CommandBufferSubmitted` now runs under `_stagingLock`, the same lock the completion path takes. `_currentStagingInfo = null` stays outside it: that field is submit-side state touched only by the submitting thread, never by the completion thread.
- `CommandBufferCompleted` now uses the atomic `_submittedStagingInfos.Remove(key, out info)` instead of `TryGetValue` followed by a separate `Remove` — one locked lookup instead of two, with identical behavior.

## Credit

Ported from TechPizza's veldrid2 fork: [`fbbe926`](https://github.com/veldrid2/veldrid2/commit/fbbe926fd1e8743a619ed544a74b06a6d4cf0c14). A direct port: the fix is self-contained and involves no API change.