### PR TITLE
[D3D11] Gate structured-buffer capability on feature level 11_0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 ### Fixed
 
+- [D3D11] `GraphicsDeviceFeatures.StructuredBuffer` reporting `true` on feature levels below 11_0, where D3D11 does not support structured buffers.
 - [Core] `TextureViewDescription`'s range-and-format constructor ignoring its format argument and using the target texture's format instead.
 - [Core] `GraphicsDevice.Dispose()` deadlocking or crashing when called more than once.
 - [Core] `Texture.Dispose()` racing concurrent creation of the texture's default view, which could free the device resource while it was still being used.

--- a/src/NeoVeldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/NeoVeldrid/D3D11/D3D11GraphicsDevice.cs
@@ -226,7 +226,7 @@ namespace NeoVeldrid.D3D11
                 depthClipDisable: true,
                 texture1D: true,
                 independentBlend: true,
-                structuredBuffer: true,
+                structuredBuffer: featureLevel >= D3DFeatureLevel.Level110,
                 subsetTextureView: true,
                 commandListDebugMarkers: featureLevel >= D3DFeatureLevel.Level111,
                 bufferRangeBinding: featureLevel >= D3DFeatureLevel.Level111,


### PR DESCRIPTION
`GraphicsDeviceFeatures.StructuredBuffer` was hardcoded to `true` on the D3D11 backend. Structured buffers need shader model 5.0, which is feature level 11_0, so on FL 10.x hardware (or WARP forced to a lower level) the capability was reported as available when it isn't. A caller that checks the flag would be told yes and then hit an opaque failure later when it actually tries to create or bind a structured buffer.

## What changed

`structuredBuffer: true` becomes `structuredBuffer: featureLevel >= D3DFeatureLevel.Level110`. The two neighbouring capabilities, `commandListDebugMarkers` and `bufferRangeBinding`, already gate this way, but on `Level111` (11_1) since those need the higher level. Structured buffers gate on 11_0.

## Credit

Ported from TechPizza's veldrid2 fork: [`843b885`](https://github.com/veldrid2/veldrid2/commit/843b885e55a61e0186aae8f1d5a2711c82a01999).
