### PR TITLE
[ImGui] Upload projection matrix through the command list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 ### Fixed
 
+- [ImGui] `ImGuiRenderer`'s projection-matrix upload bypassing the command list.
 - [D3D11] `GraphicsDeviceFeatures.StructuredBuffer` reporting `true` on feature levels below 11_0, where D3D11 does not support structured buffers.
 - [Core] `TextureViewDescription`'s range-and-format constructor ignoring its format argument and using the target texture's format instead.
 - [Core] `GraphicsDevice.Dispose()` deadlocking or crashing when called more than once.

--- a/src/NeoVeldrid.ImGui/ImGuiRenderer.cs
+++ b/src/NeoVeldrid.ImGui/ImGuiRenderer.cs
@@ -696,7 +696,7 @@ namespace NeoVeldrid
                     -1.0f,
                     1.0f);
 
-                _gd.UpdateBuffer(_projMatrixBuffer, 0, ref mvp);
+                cl.UpdateBuffer(_projMatrixBuffer, 0, ref mvp);
             }
 
             cl.SetVertexBuffer(0, _vertexBuffer);


### PR DESCRIPTION
`ImGuiRenderer.RenderImDrawData` uploaded the projection matrix with `_gd.UpdateBuffer(...)`, an immediate device operation, while the draws that read that buffer were being recorded into the `CommandList`. Those are two different timelines: the device write happens at record time, the draws execute later at submit time, and Veldrid defines no ordering between a device-timeline write and a command-list-timeline read of the same resource.

It works in the common single-window, single-submit loop because the matrix only changes on resize and the immediate write lands before `SubmitCommands` is even called. It breaks where that assumption doesn't hold: a resize while a prior frame is still in flight (wrong projection for a frame, visible as flicker while dragging the window edge), a command list recorded once and submitted more than once (the replay reads whatever is in the buffer at execute time, since the list captured the binding and not the contents), or threaded recording.

## What changed

`_gd.UpdateBuffer(_projMatrixBuffer, 0, ref mvp)` becomes `cl.UpdateBuffer(...)`, so the matrix upload is recorded into the command stream in order with the draws that read it, exactly like the vertex and index uploads a few lines above already were.

## Credit

Ported from TechPizza's veldrid2 fork: [`fa19549`](https://github.com/veldrid2/veldrid2/commit/fa195497ade0d86d386a37067134340fe4412214).
