### PR TITLE
[OpenGL] Fix DSA and independent-blend capability detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 ### Fixed
 
+- [OpenGL] Direct-state-access being under-detected on GL 4.5+ drivers that no longer expose the `GL_ARB_direct_state_access` extension string.
+- [OpenGL] Independent blend being under-detected on hardware that exposes it through `GL_ARB_draw_buffers_blend` below GL 4.0.
 - [ImGui] `ImGuiRenderer`'s projection-matrix upload bypassing the command list.
 - [D3D11] `GraphicsDeviceFeatures.StructuredBuffer` reporting `true` on feature levels below 11_0, where D3D11 does not support structured buffers.
 - [Core] `TextureViewDescription`'s range-and-format constructor ignoring its format argument and using the target texture's format instead.

--- a/src/NeoVeldrid/OpenGL/OpenGLExtensions.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLExtensions.cs
@@ -23,7 +23,7 @@ namespace NeoVeldrid.OpenGL
                 || GLESVersion(3, 0);
             TextureStorageMultisample = IsExtensionSupported("GL_ARB_texture_storage_multisample")
                 || GLESVersion(3, 1);
-            ARB_DirectStateAccess = IsExtensionSupported("GL_ARB_direct_state_access");
+            ARB_DirectStateAccess = GLVersion(4, 5) || IsExtensionSupported("GL_ARB_direct_state_access"); // OpenGL 4.5
             ARB_MultiBind = IsExtensionSupported("GL_ARB_multi_bind");
             ARB_TextureView = GLVersion(4, 3) || IsExtensionSupported("GL_ARB_texture_view") // OpenGL 4.3
                 || IsExtensionSupported("GL_OES_texture_view");
@@ -45,7 +45,7 @@ namespace NeoVeldrid.OpenGL
                 || IsExtensionSupported("GL_ARB_draw_elements_base_vertex")
                 || GLESVersion(3, 2)
                 || IsExtensionSupported("GL_OES_draw_elements_base_vertex");
-            IndependentBlend = GLVersion(4, 0) || GLESVersion(3, 2);
+            IndependentBlend = GLVersion(4, 0) || IsExtensionSupported("GL_ARB_draw_buffers_blend") || GLESVersion(3, 2);
 
             DrawIndirect = GLVersion(4, 0) || IsExtensionSupported("GL_ARB_draw_indirect")
                 || GLESVersion(3, 1);


### PR DESCRIPTION
Two GL capability flags checked only an extension string, so they were under-detected on conformant drivers that expose the capability another way.

- **Direct state access** was promoted to core in GL 4.5. A conformant 4.5 driver is allowed to stop advertising the now-redundant `GL_ARB_direct_state_access` string, so the extension-only check missed it. Fixed by OR-ing in a `GLVersion(4, 5)` core-version check.
- **Independent blend** is also available *below* its GL 4.0 core promotion, through `GL_ARB_draw_buffers_blend`. That extension path was missing, so pre-4.0 hardware that supports it was reported as not.

Both now follow the same `GLVersion(...) || IsExtensionSupported(...)` idiom the file already uses for `ARB_TextureView`.

## Credit

Ported from TechPizza's veldrid2 fork: [`5d3445b`](https://github.com/veldrid2/veldrid2/commit/5d3445b) (DSA) and [`8e9413b`](https://github.com/veldrid2/veldrid2/commit/8e9413b) (independent blend).
