### PR TITLE
[Core] Allow structured buffers combined with vertex/index/indirect usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 ### Added
 
-- `[ImGui]` `ImGuiRenderer` now accepts an `autoInit: false` constructor option and exposes a public `Initialize()` method, so callers can configure `ImGui.GetIO()` (docking flags, custom fonts, etc.) before the first ImGui frame is opened.
+- [ImGui] `ImGuiRenderer` now accepts an `autoInit: false` constructor option and exposes a public `Initialize()` method, so callers can configure `ImGui.GetIO()` (docking flags, custom fonts, etc.) before the first ImGui frame is opened.
 - [Core] Added `GraphicsDevice.IsDisposed` property, matching the `IsDisposed` already exposed by every device resource.
 - [Core] Structured buffers can now be created combined with `VertexBuffer`, `IndexBuffer`, or `IndirectBuffer` usage, so a compute shader can fill a vertex, index, or indirect buffer directly (GPU-driven rendering).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 - `[ImGui]` `ImGuiRenderer` now accepts an `autoInit: false` constructor option and exposes a public `Initialize()` method, so callers can configure `ImGui.GetIO()` (docking flags, custom fonts, etc.) before the first ImGui frame is opened.
 - [Core] Added `GraphicsDevice.IsDisposed` property, matching the `IsDisposed` already exposed by every device resource.
+- [Core] Structured buffers can now be created combined with `VertexBuffer`, `IndexBuffer`, or `IndirectBuffer` usage, so a compute shader can fill a vertex, index, or indirect buffer directly (GPU-driven rendering).
 
 ### Fixed
 

--- a/src/NeoVeldrid/BufferUsage.cs
+++ b/src/NeoVeldrid/BufferUsage.cs
@@ -26,13 +26,17 @@ namespace NeoVeldrid
         /// <summary>
         /// Indicates that a <see cref="DeviceBuffer"/> can be used as a read-only structured Buffer.
         /// This flag enables the use of a Buffer in a <see cref="ResourceSet"/> as a read-only structured Buffer.
-        /// This flag can only be combined with <see cref="Dynamic"/>.
+        /// Can be combined with <see cref="VertexBuffer"/>, <see cref="IndexBuffer"/>, or <see cref="IndirectBuffer"/>
+        /// so a compute shader can fill that buffer. This combination requires
+        /// <see cref="BufferDescription.UseTypedHlslBinding"/> to be <see langword="false"/> (its default).
         /// </summary>
         StructuredBufferReadOnly = 1 << 3,
         /// <summary>
         /// Indicates that a <see cref="DeviceBuffer"/> can be used as a read-write structured Buffer.
         /// This flag enables the use of a Buffer in a <see cref="ResourceSet"/> as a read-write structured Buffer.
-        /// This flag cannot be combined with any other flag.
+        /// Can be combined with <see cref="VertexBuffer"/>, <see cref="IndexBuffer"/>, or <see cref="IndirectBuffer"/>
+        /// so a compute shader can fill that buffer. This combination requires
+        /// <see cref="BufferDescription.UseTypedHlslBinding"/> to be <see langword="false"/> (its default).
         /// </summary>
         StructuredBufferReadWrite = 1 << 4,
         /// <summary>

--- a/src/NeoVeldrid/D3D11/D3D11Buffer.cs
+++ b/src/NeoVeldrid/D3D11/D3D11Buffer.cs
@@ -48,18 +48,18 @@ namespace NeoVeldrid.D3D11
             {
                 if (useTypedHlslBinding)
                 {
-                    bd.MiscFlags = (uint)ResourceMiscFlag.BufferStructured;
+                    bd.MiscFlags |= (uint)ResourceMiscFlag.BufferStructured;
                     bd.StructureByteStride = structureByteStride;
                 }
                 else
                 {
-                    bd.MiscFlags = (uint)ResourceMiscFlag.BufferAllowRawViews;
+                    bd.MiscFlags |= (uint)ResourceMiscFlag.BufferAllowRawViews;
                 }
             }
 
             if ((usage & BufferUsage.IndirectBuffer) == BufferUsage.IndirectBuffer)
             {
-                bd.MiscFlags = (uint)ResourceMiscFlag.DrawindirectArgs;
+                bd.MiscFlags |= (uint)ResourceMiscFlag.DrawindirectArgs;
             }
 
             if ((usage & BufferUsage.Dynamic) == BufferUsage.Dynamic)

--- a/src/NeoVeldrid/ResourceFactory.cs
+++ b/src/NeoVeldrid/ResourceFactory.cs
@@ -289,6 +289,7 @@ namespace NeoVeldrid
         /// <param name="description">The desired properties of the created object.</param>
         /// <returns>A new <see cref="DeviceBuffer"/>.</returns>
         public DeviceBuffer CreateBuffer(BufferDescription description) => CreateBuffer(ref description);
+
         /// <summary>
         /// Creates a new <see cref="DeviceBuffer"/>.
         /// </summary>
@@ -311,17 +312,16 @@ namespace NeoVeldrid
                     throw new NeoVeldridException("Structured Buffer objects must have a non-zero StructureByteStride.");
                 }
 
-                if ((usage & BufferUsage.StructuredBufferReadWrite) != 0 && usage != BufferUsage.StructuredBufferReadWrite)
+                if ((usage & BufferUsage.UniformBuffer) != 0)
                 {
                     throw new NeoVeldridException(
-                        $"{nameof(BufferUsage)}.{nameof(BufferUsage.StructuredBufferReadWrite)} cannot be combined with any other flag.");
+                        $"Structured Buffer objects cannot specify {nameof(BufferUsage)}.{nameof(BufferUsage.UniformBuffer)}.");
                 }
-                else if ((usage & BufferUsage.VertexBuffer) != 0
-                    || (usage & BufferUsage.IndexBuffer) != 0
-                    || (usage & BufferUsage.IndirectBuffer) != 0)
+                if (description.UseTypedHlslBinding
+                    && (usage & (BufferUsage.VertexBuffer | BufferUsage.IndexBuffer | BufferUsage.IndirectBuffer)) != 0)
                 {
                     throw new NeoVeldridException(
-                        $"Read-Only Structured Buffer objects cannot specify {nameof(BufferUsage)}.{nameof(BufferUsage.VertexBuffer)}, {nameof(BufferUsage)}.{nameof(BufferUsage.IndexBuffer)}, or {nameof(BufferUsage)}.{nameof(BufferUsage.IndirectBuffer)}.");
+                        $"A structured buffer with {nameof(BufferDescription.UseTypedHlslBinding)} set cannot also specify {nameof(BufferUsage.VertexBuffer)}, {nameof(BufferUsage.IndexBuffer)}, or {nameof(BufferUsage.IndirectBuffer)}. Leave {nameof(BufferDescription.UseTypedHlslBinding)} false (the default) to fill a vertex, index, or indirect buffer from a compute shader.");
                 }
             }
             else if (description.StructureByteStride != 0)

--- a/tests/NeoVeldrid.Tests/BufferTests.cs
+++ b/tests/NeoVeldrid.Tests/BufferTests.cs
@@ -457,6 +457,16 @@ namespace NeoVeldrid.Tests
         }
 
         [Theory]
+        [InlineData(BufferUsage.VertexBuffer)]
+        [InlineData(BufferUsage.IndexBuffer)]
+        [InlineData(BufferUsage.IndirectBuffer)]
+        public void CreateBuffer_TypedStructuredWithVertexIndexOrIndirect_Throws(BufferUsage extra)
+        {
+            Assert.Throws<NeoVeldridException>(() => RF.CreateBuffer(new BufferDescription(
+                64, BufferUsage.StructuredBufferReadWrite | extra, 16, useTypedHlslBinding: true)));
+        }
+
+        [Theory]
         [InlineData(BufferUsage.UniformBuffer)]
         [InlineData(BufferUsage.UniformBuffer | BufferUsage.Dynamic)]
         [InlineData(BufferUsage.VertexBuffer)]

--- a/tests/NeoVeldrid.Tests/ComputeTests.cs
+++ b/tests/NeoVeldrid.Tests/ComputeTests.cs
@@ -524,6 +524,58 @@ void main()
                                 yield return new object[] { srcSetMultiple, srcBindingMultiple, dstSetMultiple, dstBindingMultiple, combinedLayout };
                             }
         }
+
+        [SkippableTheory]
+        [InlineData(BufferUsage.IndirectBuffer)]
+        [InlineData(BufferUsage.IndexBuffer)]
+        [InlineData(BufferUsage.VertexBuffer)]
+        public unsafe void FillBuffer_CombinedWithStructured(BufferUsage dstUsage)
+        {
+            Skip.IfNot(GD.Features.ComputeShader);
+
+            uint stride = (uint)sizeof(IndirectDrawIndexedArguments);
+
+            ResourceLayout layout = RF.CreateResourceLayout(new ResourceLayoutDescription(
+                new ResourceLayoutElementDescription("Params", ResourceKind.StructuredBufferReadOnly, ShaderStages.Compute),
+                new ResourceLayoutElementDescription("Destination", ResourceKind.StructuredBufferReadWrite, ShaderStages.Compute)));
+
+            DeviceBuffer paramsBuffer = RF.CreateBuffer(new BufferDescription(
+                stride, BufferUsage.StructuredBufferReadOnly, stride));
+
+            DeviceBuffer dstBuffer = RF.CreateBuffer(new BufferDescription(
+                stride, dstUsage | BufferUsage.StructuredBufferReadWrite, stride));
+
+            IndirectDrawIndexedArguments paramsValue = new IndirectDrawIndexedArguments
+            {
+                FirstIndex = 1,
+                FirstInstance = 2,
+                IndexCount = 3,
+                InstanceCount = 4,
+                VertexOffset = 5,
+            };
+            GD.UpdateBuffer(paramsBuffer, 0, paramsValue);
+
+            ResourceSet rs = RF.CreateResourceSet(new ResourceSetDescription(layout, paramsBuffer, dstBuffer));
+
+            Pipeline pipeline = RF.CreateComputePipeline(new ComputePipelineDescription(
+                TestShaders.LoadCompute(RF, "FillIndirectBufferComputeTest"),
+                layout,
+                1, 1, 1));
+
+            CommandList cl = RF.CreateCommandList();
+            cl.Begin();
+            cl.SetPipeline(pipeline);
+            cl.SetComputeResourceSet(0, rs);
+            cl.Dispatch(1, 1, 1);
+            cl.End();
+            GD.SubmitCommands(cl);
+            GD.WaitForIdle();
+
+            DeviceBuffer dstReadback = GetReadback(dstBuffer);
+            MappedResourceView<IndirectDrawIndexedArguments> dstView = GD.Map<IndirectDrawIndexedArguments>(dstReadback, MapMode.Read);
+            Assert.Equal(paramsValue, dstView[0]);
+            GD.Unmap(dstReadback);
+        }
     }
 
 #if TEST_OPENGL

--- a/tests/NeoVeldrid.Tests/Shaders/FillIndirectBufferComputeTest.comp
+++ b/tests/NeoVeldrid.Tests/Shaders/FillIndirectBufferComputeTest.comp
@@ -1,0 +1,28 @@
+#version 450
+
+struct IndirectDrawIndexedArguments
+{
+    uint IndexCount;
+    uint InstanceCount;
+    uint FirstIndex;
+    int VertexOffset;
+    uint FirstInstance;
+};
+
+layout(std430, set = 0, binding = 0) readonly buffer Params
+{
+    IndirectDrawIndexedArguments field_Params[];
+};
+
+layout(std430, set = 0, binding = 1) buffer Destination
+{
+    IndirectDrawIndexedArguments field_Destination[];
+};
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+void main()
+{
+    uint index = gl_GlobalInvocationID.x;
+    field_Destination[index] = field_Params[index];
+}


### PR DESCRIPTION
A buffer can now carry structured-buffer usage together with `VertexBuffer`, `IndexBuffer`, or `IndirectBuffer`. That lets a compute shader fill a vertex, index, or indirect buffer directly on the GPU, the foundation for GPU-driven rendering: a compute pass writes an `IndirectDrawIndexedArguments` (or geometry, or indices) into a buffer that the draw then consumes the same frame, with no CPU round-trip.

Previously `CreateBuffer` rejected the combination outright.

## What changed

- **Validation relaxed** in `ResourceFactory`. A structured buffer combined with vertex/index/indirect is allowed; the only structural conflict left is structured + `UniformBuffer`.
- **D3D11 buffer flags** now OR together instead of overwriting. The indirect-args flag was clobbering the structured/raw-view flag, so a combined buffer came out missing a capability. This is what makes the feature actually work on D3D11, not just pass validation.
- **`BufferUsage` docs** updated to describe the new combinability accurately.

Vulkan needed no change (it already ORs every usage bit) and OpenGL buffers are typeless, so the backend work is D3D11-only.

## Validation keeps its guarantee

There are two HLSL binding modes for a structured buffer: raw (`ByteAddressBuffer`, the default) and typed (`StructuredBuffer<T>`). D3D11 accepts the raw form combined with vertex/index/indirect, but rejects the typed form, it returns `E_INVALIDARG` from `CreateBuffer`. Rather than let that leak through as an opaque driver error on one backend, the relaxed validation still rejects the typed combination up front, uniformly, with a clear message pointing at the default binding. So the "validate illegal combinations before they reach the backend" contract holds.

## Tests

- A compute shader fills a vertex/index/indirect buffer that's also a read-write structured buffer; the contents are read back and verified on every compute-capable backend.
- The typed combination is asserted to throw `NeoVeldridException` on all backends.

## Credit

The feature and the D3D11 flag fix are ported from TechPizza's veldrid2 fork: [`5c0706c`](https://github.com/veldrid2/veldrid2/commit/5c0706c0441a2fba97820ce298a163f7d3e9fec8) and [`2b36e90`](https://github.com/veldrid2/veldrid2/commit/2b36e90f5e7e821eeed1909cf219b1b5624d6f71). The typed-combination guard and the doc updates are additions here; veldrid2's relaxation lets the typed case fall through to the backend.
