### PR TITLE
[Core] Validate unsupported Dynamic buffer-usage combinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 ### Fixed
 
+- [Core] Missing validation for the unsupported `BufferUsage` combinations `Dynamic | StructuredBufferReadWrite` and `Dynamic | IndirectBuffer`.
 - [OpenGL] Direct-state-access being under-detected on GL 4.5+ drivers that no longer expose the `GL_ARB_direct_state_access` extension string.
 - [OpenGL] Independent blend being under-detected on hardware that exposes it through `GL_ARB_draw_buffers_blend` below GL 4.0.
 - [ImGui] `ImGuiRenderer`'s projection-matrix upload bypassing the command list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 ### Internal
 
+- [Tests] Added negative tests for the `CreateBuffer` usage-validation rules that lacked coverage (structured stride rules, structured + uniform, staging exclusivity, uniform size).
 - [Vulkan] Replaced the internal `StackList` stack-buffer helper with `stackalloc`.
 - Marked all non-mutating struct members `readonly` across the codebase.
 

--- a/src/NeoVeldrid/ResourceFactory.cs
+++ b/src/NeoVeldrid/ResourceFactory.cs
@@ -332,6 +332,12 @@ namespace NeoVeldrid
             {
                 throw new NeoVeldridException("Buffers with Staging Usage must not specify any other Usage flags.");
             }
+            if ((usage & BufferUsage.Dynamic) != 0
+                && (usage & (BufferUsage.StructuredBufferReadWrite | BufferUsage.IndirectBuffer)) != 0)
+            {
+                throw new NeoVeldridException(
+                    $"{nameof(BufferUsage)}.{nameof(BufferUsage.Dynamic)} cannot be combined with {nameof(BufferUsage.StructuredBufferReadWrite)} or {nameof(BufferUsage.IndirectBuffer)}.");
+            }
             if ((usage & BufferUsage.UniformBuffer) != 0 && (description.SizeInBytes % 16) != 0)
             {
                 throw new NeoVeldridException($"Uniform buffer size must be a multiple of 16 bytes.");

--- a/tests/NeoVeldrid.Tests/BufferTests.cs
+++ b/tests/NeoVeldrid.Tests/BufferTests.cs
@@ -467,6 +467,26 @@ namespace NeoVeldrid.Tests
         }
 
         [Theory]
+        [InlineData(BufferUsage.Dynamic | BufferUsage.IndirectBuffer)]
+        [InlineData(BufferUsage.Dynamic | BufferUsage.StructuredBufferReadWrite)]
+        public void CreateBuffer_DynamicWithStructuredRwOrIndirect_Throws(BufferUsage usage)
+        {
+            uint stride = (usage & BufferUsage.StructuredBufferReadWrite) != 0 ? 16u : 0u;
+            Assert.Throws<NeoVeldridException>(() => RF.CreateBuffer(new BufferDescription(64, usage, stride)));
+        }
+
+        [Theory]
+        [InlineData(BufferUsage.StructuredBufferReadOnly, 0u, 64u)]                                  // structured requires a stride
+        [InlineData(BufferUsage.VertexBuffer, 16u, 64u)]                                             // non-structured forbids a stride
+        [InlineData(BufferUsage.StructuredBufferReadOnly | BufferUsage.UniformBuffer, 16u, 64u)]     // structured cannot be a uniform buffer
+        [InlineData(BufferUsage.Staging | BufferUsage.VertexBuffer, 0u, 64u)]                        // staging is exclusive
+        [InlineData(BufferUsage.UniformBuffer, 0u, 20u)]                                             // uniform size must be a multiple of 16
+        public void CreateBuffer_InvalidDescription_Throws(BufferUsage usage, uint stride, uint size)
+        {
+            Assert.Throws<NeoVeldridException>(() => RF.CreateBuffer(new BufferDescription(size, usage, stride)));
+        }
+
+        [Theory]
         [InlineData(BufferUsage.UniformBuffer)]
         [InlineData(BufferUsage.UniformBuffer | BufferUsage.Dynamic)]
         [InlineData(BufferUsage.VertexBuffer)]


### PR DESCRIPTION
`CreateBuffer` accepted two `BufferUsage` combinations that the `BufferUsage` docs already describe as unsupported: `Dynamic | StructuredBufferReadWrite` and `Dynamic | IndirectBuffer`. Both fail on D3D11, a `D3D11_USAGE_DYNAMIC` buffer can't carry a UAV or a draw-indirect-args flag, so `CreateBuffer` returns `E_INVALIDARG`, but Vulkan, OpenGL, and OpenGL ES silently accepted them. The same code built a usable buffer on three backends and threw an opaque driver error on the fourth.

The usage validation exists to catch exactly this: a combination that's illegal on any backend should be rejected the same way everywhere, up front, before it reaches a driver.

## What changed

- `ResourceFactory.CreateBuffer` now throws a clear `NeoVeldridException` for those two combinations on every backend. It enforces a restriction the `BufferUsage` docs already stated, so the docs needed no update.
- Added negative tests for the buffer-creation validation rules that had none: the structured-buffer stride rules (both directions), structured combined with `UniformBuffer`, staging exclusivity, and the uniform 16-byte size rule.

## Not a breaking change

The combinations were always documented as unsupported and already failed on D3D11, so no portable code could have relied on them. This enforces an existing documented invariant rather than changing the contract.
