### PR TITLE
[Core] Remove Android and iOS platform support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 ## [Unreleased]
 
+### Removed
+
+- [Core] Mobile-only `SwapchainSource.CreateAndroidSurface`, `SwapchainSource.CreateUIView`, and the `GraphicsDevice.CreateOpenGLES(GraphicsDeviceOptions, SwapchainDescription)` overload. NeoVeldrid targets desktop platforms only.
+
+### Internal
+
+- Removed dead Android and iOS code paths left over from the Silk.NET port.
+
 ## [1.1.0] - 2026-05-25
 
 First minor release for NeoVeldrid. This release comes with a few tiny new features and a lot of bug fixes that improve the stability. Our goal with NeoVeldrid is to make it reliable and rock-solid to ship real high performance applications and games in dotnet.

--- a/docs/articles/advanced/implementation/opengl.md
+++ b/docs/articles/advanced/implementation/opengl.md
@@ -1,6 +1,6 @@
 # OpenGL Backend
 
-The OpenGL backend is a multi-platform backend implemented using OpenGL. It is supported on most desktop platforms, except for UWP. OpenGL 3.0 or higher is required for an OpenGL [GraphicsDevice](xref:NeoVeldrid.GraphicsDevice).
+The OpenGL backend is a multi-platform backend implemented using OpenGL. It is supported on Windows and Linux. OpenGL 3.0 or higher is required for an OpenGL [GraphicsDevice](xref:NeoVeldrid.GraphicsDevice).
 
 The OpenGL ES backend is more-or-less the same as the OpenGL backend. There exist several minor differences related to how extensions are queried, and the exact names of some GL functions are different. NeoVeldrid requires OpenGL ES 3.0 or higher to create an OpenGL ES GraphicsDevice.
 

--- a/docs/articles/advanced/implementation/overview.md
+++ b/docs/articles/advanced/implementation/overview.md
@@ -4,7 +4,7 @@ NeoVeldrid is split roughly into two parts: the portable, public interface which
 
 Normal users of NeoVeldrid may not be interested in this information, because it dives into the internal implementation details of the library, which is not necessary for ordinary, correct usage of the library. However, users familiar with a particular graphics API (OpenGL, Direct3D, etc.) may find it helpful to see how concepts from that API map to NeoVeldrid. Users interested in contributing to NeoVeldrid will also find this section useful.
 
-The descriptions in the following sections reflect NeoVeldrid as of version 4.2.0. As they are internal details, they may subtly change over time as optimizations and fixes are integrated into the codebase.
+The descriptions in the following sections reflect the current implementation of NeoVeldrid. As they are internal details, they may subtly change over time as optimizations and fixes are integrated into the codebase.
 
 -------------------------------------
 

--- a/docs/articles/advanced/implementation/vulkan.md
+++ b/docs/articles/advanced/implementation/vulkan.md
@@ -1,6 +1,6 @@
 # Vulkan Backend
 
-The Vulkan backend is a multi-platform backend implemented using the Vulkan API. Vulkan is supported on Windows, Linux, and Android. Vulkan's API is very close to NeoVeldrid's and as such this is a fairly simple, straightforward backend.
+The Vulkan backend is a multi-platform backend implemented using the Vulkan API. Vulkan is supported on Windows, Linux, and macOS (via MoltenVK). Vulkan's API is very close to NeoVeldrid's and as such this is a fairly simple, straightforward backend.
 
 Vulkan [GraphicsDevices](xref:NeoVeldrid.GraphicsDevice) are created from a [VkSurfaceSource](xref:NeoVeldrid.Vk.VkSurfaceSource), which is a platform-specific object used to create a Vulkan surface (VkSurfaceKHR). The following helper functions are available:
 

--- a/docs/articles/core-concepts/swapchains.md
+++ b/docs/articles/core-concepts/swapchains.md
@@ -38,12 +38,13 @@ NOTE: Calling any of the above members is equivalent to accessing the same membe
 
 Like other resources, it is possible to create and destroy extra Swapchains at runtime, using a [ResourceFactory](xref:NeoVeldrid.ResourceFactory) and a [SwapchainDescription](xref:NeoVeldrid.SwapchainDescription). Constructing a SwapchainDescription requires a [SwapchainSource](xref:NeoVeldrid.SwapchainSource), which is a special kind of NeoVeldrid object representing a renderable surface that the application controls. Since this component interacts with the OS and its windowing system, it is platform-specific and created in a special way. There are a variety of static factory methods which allow you to create a SwapchainSource for a particular kind of operating system and UI framework. Due to platform limitations, each kind of SwapchainSource can only be used to create a Swapchain for a limited set of GraphicsDevice types.
 
-| Method | Vulkan | Direct3D 11 | OpenGL ES |
-| ------ | ------ | ----------- | --------- |
-| [CreateWin32(IntPtr hwnd, IntPtr hinstance)](xref:NeoVeldrid.SwapchainSource#NeoVeldrid_SwapchainSource_CreateWin32_System_IntPtr_System_IntPtr_) | ✓ | ✓ | |
-| [CreateXlib(IntPtr display, IntPtr window)](xref:NeoVeldrid.SwapchainSource#NeoVeldrid_SwapchainSource_CreateXlib_System_IntPtr_System_IntPtr_) | ✓ | | |
-| [CreateNSWindow(IntPtr nsWindow)](xref:NeoVeldrid.SwapchainSource#NeoVeldrid_SwapchainSource_CreateNSWindow_System_IntPtr_) | ✓* | | |
-| [CreateAndroidSurface(IntPtr surfaceHandle, IntPtr jniEnv)](xref:NeoVeldrid.SwapchainSource#NeoVeldrid_SwapchainSource_CreateAndroidSurface_System_IntPtr_System_IntPtr_) | ✓ | | ✓ |
+| Method | Vulkan | Direct3D 11 |
+| ------ | ------ | ----------- |
+| [CreateWin32(IntPtr hwnd, IntPtr hinstance)](xref:NeoVeldrid.SwapchainSource#NeoVeldrid_SwapchainSource_CreateWin32_System_IntPtr_System_IntPtr_) | ✓ | ✓ |
+| [CreateXlib(IntPtr display, IntPtr window)](xref:NeoVeldrid.SwapchainSource#NeoVeldrid_SwapchainSource_CreateXlib_System_IntPtr_System_IntPtr_) | ✓ | |
+| [CreateWayland(IntPtr display, IntPtr surface)](xref:NeoVeldrid.SwapchainSource#NeoVeldrid_SwapchainSource_CreateWayland_System_IntPtr_System_IntPtr_) | ✓ | |
+| [CreateNSWindow(IntPtr nsWindow)](xref:NeoVeldrid.SwapchainSource#NeoVeldrid_SwapchainSource_CreateNSWindow_System_IntPtr_) | ✓* | |
+| [CreateNSView(IntPtr nsView)](xref:NeoVeldrid.SwapchainSource#NeoVeldrid_SwapchainSource_CreateNSView_System_IntPtr_) | ✓* | |
 
 _ * Vulkan support on macOS requires [MoltenVK](https://github.com/KhronosGroup/MoltenVK), which is bundled automatically. _
 

--- a/docs/articles/shaders/shaders.md
+++ b/docs/articles/shaders/shaders.md
@@ -21,7 +21,7 @@ In most cases, you will want to write your shader code only once, in a single la
 
 ## Specialization Constants
 
-NeoVeldrid 4.4.0 introduces the concept of "Specialization Constants", which enable you to create Shaders with parameterized behavior that can be "specialized" when a [Pipeline](xref:NeoVeldrid.Pipeline) is created, with no runtime overhead. See the [Specialization Constants](xref:specialization-constants) article for more information.
+NeoVeldrid supports "Specialization Constants", which enable you to create Shaders with parameterized behavior that can be "specialized" when a [Pipeline](xref:NeoVeldrid.Pipeline) is created, with no runtime overhead. See the [Specialization Constants](xref:specialization-constants) article for more information.
 
 ## Shader Resources
 

--- a/src/NeoVeldrid.SDL2/Sdl2Window.cs
+++ b/src/NeoVeldrid.SDL2/Sdl2Window.cs
@@ -1004,8 +1004,6 @@ namespace NeoVeldrid.Sdl2
                     return (IntPtr)wmInfo.Info.Wayland.Surface;
                 case SysWMType.Cocoa:
                     return (IntPtr)wmInfo.Info.Cocoa.Window;
-                case SysWMType.Android:
-                    return (IntPtr)wmInfo.Info.Android.Window;
                 default:
                     return (IntPtr)_window;
             }

--- a/src/NeoVeldrid/GraphicsDevice.cs
+++ b/src/NeoVeldrid/GraphicsDevice.cs
@@ -1137,21 +1137,6 @@ namespace NeoVeldrid
         {
             return new OpenGL.OpenGLGraphicsDevice(options, platformInfo, width, height);
         }
-
-        /// <summary>
-        /// Creates a new <see cref="GraphicsDevice"/> using OpenGL ES, with a main Swapchain.
-        /// This overload can only be used on iOS or Android to create a GraphicsDevice for an Android Surface or an iOS UIView.
-        /// </summary>
-        /// <param name="options">Describes several common properties of the GraphicsDevice.</param>
-        /// <param name="swapchainDescription">A description of the main Swapchain to create.
-        /// The SwapchainSource must have been created from an Android Surface or an iOS UIView.</param>
-        /// <returns>A new <see cref="GraphicsDevice"/> using the OpenGL or OpenGL ES API.</returns>
-        public static GraphicsDevice CreateOpenGLES(
-            GraphicsDeviceOptions options,
-            SwapchainDescription swapchainDescription)
-        {
-            return new OpenGL.OpenGLGraphicsDevice(options, swapchainDescription);
-        }
 #endif
 
     }

--- a/src/NeoVeldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -435,43 +435,6 @@ namespace NeoVeldrid.OpenGL
             return data[0] > 0.6f;
         }
 
-        public OpenGLGraphicsDevice(GraphicsDeviceOptions options, SwapchainDescription swapchainDescription)
-        {
-            options.SwapchainDepthFormat = swapchainDescription.DepthFormat;
-            options.SwapchainSrgbFormat = swapchainDescription.ColorSrgb;
-            options.SyncToVerticalBlank = swapchainDescription.SyncToVerticalBlank;
-
-            SwapchainSource source = swapchainDescription.Source;
-            if (source is UIViewSwapchainSource uiViewSource)
-            {
-                InitializeUIView(options, uiViewSource.UIView);
-            }
-            else if (source is AndroidSurfaceSwapchainSource androidSource)
-            {
-                InitializeANativeWindow(options, IntPtr.Zero, swapchainDescription);
-            }
-            else
-            {
-                throw new NeoVeldridException(
-                    "This function does not support creating an OpenGLES GraphicsDevice with the given SwapchainSource.");
-            }
-        }
-
-        private void InitializeUIView(GraphicsDeviceOptions options, IntPtr uIViewPtr)
-        {
-            throw new PlatformNotSupportedException(
-                "iOS (EAGL/UIView) OpenGL ES is not supported. Use Vulkan via MoltenVK on Apple platforms.");
-        }
-
-        private void InitializeANativeWindow(
-            GraphicsDeviceOptions options,
-            IntPtr aNativeWindow,
-            SwapchainDescription swapchainDescription)
-        {
-            throw new PlatformNotSupportedException(
-                "Android OpenGL ES is not supported in veldrid-silk.");
-        }
-
         private static int GetDepthBits(PixelFormat value)
         {
             switch (value)

--- a/src/NeoVeldrid/SwapchainSource.cs
+++ b/src/NeoVeldrid/SwapchainSource.cs
@@ -48,25 +48,6 @@ namespace NeoVeldrid
         public static SwapchainSource CreateNSWindow(IntPtr nsWindow) => new NSWindowSwapchainSource(nsWindow);
 
         /// <summary>
-        /// Creates a new SwapchainSource for the given UIView.
-        /// </summary>
-        /// <param name="uiView">The UIView's native handle.</param>
-        /// <returns>A new SwapchainSource which can be used to create a Vulkan <see cref="Swapchain"/> or an OpenGLES
-        /// <see cref="GraphicsDevice"/> for the given UIView.
-        /// </returns>
-        public static SwapchainSource CreateUIView(IntPtr uiView) => new UIViewSwapchainSource(uiView);
-
-        /// <summary>
-        /// Creates a new SwapchainSource for the given Android Surface.
-        /// </summary>
-        /// <param name="surfaceHandle">The handle of the Android Surface.</param>
-        /// <param name="jniEnv">The Java Native Interface Environment handle.</param>
-        /// <returns>A new SwapchainSource which can be used to create a Vulkan <see cref="Swapchain"/> or an OpenGLES
-        /// <see cref="GraphicsDevice"/> for the given Android Surface.</returns>
-        public static SwapchainSource CreateAndroidSurface(IntPtr surfaceHandle, IntPtr jniEnv)
-            => new AndroidSurfaceSwapchainSource(surfaceHandle, jniEnv);
-
-        /// <summary>
         /// Creates a new SwapchainSource for the given NSView.
         /// </summary>
         /// <param name="nsView">A pointer to an NSView.</param>
@@ -119,28 +100,6 @@ namespace NeoVeldrid
         public NSWindowSwapchainSource(IntPtr nsWindow)
         {
             NSWindow = nsWindow;
-        }
-    }
-
-    internal class UIViewSwapchainSource : SwapchainSource
-    {
-        public IntPtr UIView { get; }
-
-        public UIViewSwapchainSource(IntPtr uiView)
-        {
-            UIView = uiView;
-        }
-    }
-
-    internal class AndroidSurfaceSwapchainSource : SwapchainSource
-    {
-        public IntPtr Surface { get; }
-        public IntPtr JniEnv { get; }
-
-        public AndroidSurfaceSwapchainSource(IntPtr surfaceHandle, IntPtr jniEnv)
-        {
-            Surface = surfaceHandle;
-            JniEnv = jniEnv;
         }
     }
 

--- a/src/NeoVeldrid/Vk/CommonStrings.cs
+++ b/src/NeoVeldrid/Vk/CommonStrings.cs
@@ -7,10 +7,8 @@
         public static FixedUtf8String VK_KHR_XCB_SURFACE_EXTENSION_NAME { get; } = "VK_KHR_xcb_surface";
         public static FixedUtf8String VK_KHR_XLIB_SURFACE_EXTENSION_NAME { get; } = "VK_KHR_xlib_surface";
         public static FixedUtf8String VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME { get; } = "VK_KHR_wayland_surface";
-        public static FixedUtf8String VK_KHR_ANDROID_SURFACE_EXTENSION_NAME { get; } = "VK_KHR_android_surface";
         public static FixedUtf8String VK_KHR_SWAPCHAIN_EXTENSION_NAME { get; } = "VK_KHR_swapchain";
         public static FixedUtf8String VK_MVK_MACOS_SURFACE_EXTENSION_NAME { get; } = "VK_MVK_macos_surface";
-        public static FixedUtf8String VK_MVK_IOS_SURFACE_EXTENSION_NAME { get; } = "VK_MVK_ios_surface";
         public static FixedUtf8String VK_EXT_METAL_SURFACE_EXTENSION_NAME { get; } = "VK_EXT_metal_surface";
         public static FixedUtf8String VK_EXT_DEBUG_REPORT_EXTENSION_NAME { get; } = "VK_EXT_debug_report";
         public static FixedUtf8String VK_EXT_DEBUG_MARKER_EXTENSION_NAME { get; } = "VK_EXT_debug_marker";

--- a/src/NeoVeldrid/Vk/VkGraphicsDevice.cs
+++ b/src/NeoVeldrid/Vk/VkGraphicsDevice.cs
@@ -514,16 +514,8 @@ namespace NeoVeldrid.Vk
                     _surfaceExtensions.Add(CommonStrings.VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
                 }
             }
-            else if (
-#if NET5_0_OR_GREATER
-                OperatingSystem.IsAndroid() ||
-#endif
-                RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (availableInstanceExtensions.Contains(CommonStrings.VK_KHR_ANDROID_SURFACE_EXTENSION_NAME))
-                {
-                    _surfaceExtensions.Add(CommonStrings.VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
-                }
                 if (availableInstanceExtensions.Contains(CommonStrings.VK_KHR_XLIB_SURFACE_EXTENSION_NAME))
                 {
                     _surfaceExtensions.Add(CommonStrings.VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
@@ -544,10 +536,6 @@ namespace NeoVeldrid.Vk
                     if (availableInstanceExtensions.Contains(CommonStrings.VK_MVK_MACOS_SURFACE_EXTENSION_NAME))
                     {
                         _surfaceExtensions.Add(CommonStrings.VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
-                    }
-                    if (availableInstanceExtensions.Contains(CommonStrings.VK_MVK_IOS_SURFACE_EXTENSION_NAME))
-                    {
-                        _surfaceExtensions.Add(CommonStrings.VK_MVK_IOS_SURFACE_EXTENSION_NAME);
                     }
                 }
             }
@@ -1468,33 +1456,13 @@ namespace NeoVeldrid.Vk
             {
                 return instanceExtensions.Contains(CommonStrings.VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
             }
-#if NET5_0_OR_GREATER
-            else if (OperatingSystem.IsAndroid())
-            {
-                return instanceExtensions.Contains(CommonStrings.VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
-            }
-#endif
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (RuntimeInformation.OSDescription.Contains("Unix")) // Android
-                {
-                    return instanceExtensions.Contains(CommonStrings.VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
-                }
-                else
-                {
-                    return instanceExtensions.Contains(CommonStrings.VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
-                }
+                return instanceExtensions.Contains(CommonStrings.VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                if (RuntimeInformation.OSDescription.Contains("Darwin")) // macOS
-                {
-                    return instanceExtensions.Contains(CommonStrings.VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
-                }
-                else // iOS
-                {
-                    return instanceExtensions.Contains(CommonStrings.VK_MVK_IOS_SURFACE_EXTENSION_NAME);
-                }
+                return instanceExtensions.Contains(CommonStrings.VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
             }
 
             return false;

--- a/src/NeoVeldrid/Vk/VkSurfaceUtil.cs
+++ b/src/NeoVeldrid/Vk/VkSurfaceUtil.cs
@@ -38,12 +38,6 @@ namespace NeoVeldrid.Vk
                         throw new NeoVeldridException($"The required instance extension was not available: {CommonStrings.VK_KHR_WIN32_SURFACE_EXTENSION_NAME}");
                     }
                     return CreateWin32(gd, instance, win32Source);
-                case AndroidSurfaceSwapchainSource androidSource:
-                    if (doCheck && !gd.HasSurfaceExtension(CommonStrings.VK_KHR_ANDROID_SURFACE_EXTENSION_NAME))
-                    {
-                        throw new NeoVeldridException($"The required instance extension was not available: {CommonStrings.VK_KHR_ANDROID_SURFACE_EXTENSION_NAME}");
-                    }
-                    return CreateAndroidSurface(gd, instance, androidSource);
                 case NSWindowSwapchainSource nsWindowSource:
                     if (doCheck)
                     {
@@ -76,22 +70,6 @@ namespace NeoVeldrid.Vk
                     }
 
                     return CreateNSViewSurface(gd, instance, nsViewSource, false);
-                case UIViewSwapchainSource uiViewSource:
-                    if (doCheck)
-                    {
-                        bool hasMetalExtension = gd.HasSurfaceExtension(CommonStrings.VK_EXT_METAL_SURFACE_EXTENSION_NAME);
-                        if (hasMetalExtension || gd.HasSurfaceExtension(CommonStrings.VK_MVK_IOS_SURFACE_EXTENSION_NAME))
-                        {
-                            return CreateUIViewSurface(gd, instance, uiViewSource, hasMetalExtension);
-                        }
-                        else
-                        {
-                            throw new NeoVeldridException($"Neither iOS surface extension was available: " +
-                                $"{CommonStrings.VK_EXT_METAL_SURFACE_EXTENSION_NAME}, {CommonStrings.VK_MVK_IOS_SURFACE_EXTENSION_NAME}");
-                        }
-                    }
-
-                    return CreateUIViewSurface(gd, instance, uiViewSource, false);
                 default:
                     throw new NeoVeldridException($"The provided SwapchainSource cannot be used to create a Vulkan surface.");
             }
@@ -155,13 +133,6 @@ namespace NeoVeldrid.Vk
             Result result = khrWaylandSurface.CreateWaylandSurface(instance, in wsci, null, out surface);
             CheckResult(result);
             return surface;
-        }
-
-        private static SurfaceKHR CreateAndroidSurface(VkGraphicsDevice gd, Instance instance, AndroidSurfaceSwapchainSource androidSource)
-        {
-            // TODO: Android surface creation requires platform-specific ANativeWindow bindings.
-            // Will be re-enabled when Silk.NET.Windowing handles platform surfaces (Phase 2).
-            throw new PlatformNotSupportedException("Android Vulkan surface creation is not yet supported in the Silk.NET port.");
         }
 
         private static unsafe SurfaceKHR CreateNSWindowSurface(VkGraphicsDevice gd, Instance instance, NSWindowSwapchainSource nsWindowSource, bool hasExtMetalSurface)
@@ -232,11 +203,6 @@ namespace NeoVeldrid.Vk
             metalLayer = ObjC.MsgSend(metalLayer, ObjC.Sel("init"));
             ObjC.MsgSendPtr(nsView, ObjC.Sel("setLayer:"), metalLayer);
             return metalLayer;
-        }
-
-        private static SurfaceKHR CreateUIViewSurface(VkGraphicsDevice gd, Instance instance, UIViewSwapchainSource uiViewSource, bool hasExtMetalSurface)
-        {
-            throw new PlatformNotSupportedException("iOS Vulkan surface creation is not yet supported in the Silk.NET port.");
         }
 
         // Minimal ObjC runtime P/Invoke for macOS surface creation.


### PR DESCRIPTION
NeoVeldrid targets the desktop: Windows, macOS, and Linux. The Silk.NET port left behind Android and iOS code paths that were never wired up, every one threw `PlatformNotSupportedException` or hit an unreachable branch. This removes that dead surface and brings the docs in line with the platforms NeoVeldrid actually runs on.

## What's removed

- **Public API**: `SwapchainSource.CreateAndroidSurface`, `SwapchainSource.CreateUIView`, and the `GraphicsDevice.CreateOpenGLES(GraphicsDeviceOptions, SwapchainDescription)` overload. That overload only accepted the two mobile swapchain sources and threw on everything else, so it was a mobile-only entry point despite the generic name.
- **Internal plumbing**: the Android/iOS surface-creation branches in the Vulkan backend, the `OperatingSystem.IsAndroid()` checks and Android/iOS surface-extension handling in `VkGraphicsDevice`, and the SDL `SysWMType.Android` window-handle case.

## What's preserved

- **Desktop OpenGL ES**: untouched. `GraphicsBackend.OpenGLES` still creates a device through `CreateOpenGL` and the startup helpers; it never went through a `SwapchainSource`.
- **macOS**: the `CreateNSWindow` / `CreateNSView` swapchain sources and the MoltenVK path stay, since macOS runs Vulkan through MoltenVK.

## Docs

The articles now describe only the supported platforms: Vulkan on Windows/Linux/macOS, OpenGL on Windows/Linux, and a `SwapchainSource` table without the mobile rows. Also cleaned up two stale Veldrid-era version numbers (4.2.0, 4.4.0) that don't apply to NeoVeldrid.

## Compatibility

These were public methods, so this is an API removal. Because each one threw at runtime on every supported platform, no working desktop code could have depended on them.
