### PR TITLE
[Core] Add IsDebugRequested and IsDebugActive to GraphicsDevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 ## [Unreleased]
 
+### Added
+
+- [Core] `GraphicsDevice.IsDebugRequested` and `GraphicsDevice.IsDebugActive` properties to query whether debug mode was requested and whether the API's debug or validation facilities are actually active.
+
 ### Removed
 
 - [Core] Mobile-only `SwapchainSource.CreateAndroidSurface`, `SwapchainSource.CreateUIView`, and the `GraphicsDevice.CreateOpenGLES(GraphicsDeviceOptions, SwapchainDescription)` overload. NeoVeldrid targets desktop platforms only.

--- a/src/NeoVeldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/NeoVeldrid/D3D11/D3D11GraphicsDevice.cs
@@ -26,6 +26,7 @@ namespace NeoVeldrid.D3D11
         private readonly D3D11Swapchain _mainSwapchain;
         private readonly bool _supportsConcurrentResources;
         private readonly bool _supportsCommandLists;
+        private readonly bool _debugActive;
         private readonly object _immediateContextLock = new object();
         private readonly BackendInfoD3D11 _d3d11Info;
 
@@ -52,13 +53,13 @@ namespace NeoVeldrid.D3D11
 
         public override bool IsClipSpaceYInverted => false;
 
+        public override bool IsDebugActive => _debugActive;
+
         public override ResourceFactory ResourceFactory => _d3d11ResourceFactory;
 
         public ID3D11Device* Device => _device;
 
         public IDXGIAdapter* Adapter => _dxgiAdapter;
-
-        public bool IsDebugEnabled { get; }
 
         public bool SupportsConcurrentResources => _supportsConcurrentResources;
 
@@ -84,6 +85,7 @@ namespace NeoVeldrid.D3D11
 #pragma warning restore CS0618
 
             var flags = (CreateDeviceFlag)options.DeviceCreationFlags;
+            IsDebugRequested = (flags & CreateDeviceFlag.Debug) != 0;
 #if DEBUG
             flags |= CreateDeviceFlag.Debug;
 #endif
@@ -205,7 +207,7 @@ namespace NeoVeldrid.D3D11
             _supportsConcurrentResources = threadingData.DriverConcurrentCreates;
             _supportsCommandLists = threadingData.DriverCommandLists;
 
-            IsDebugEnabled = (flags & CreateDeviceFlag.Debug) != 0;
+            _debugActive = (flags & CreateDeviceFlag.Debug) != 0;
 
             // Check double precision support
             FeatureDataDoubles doublesData;
@@ -748,7 +750,7 @@ namespace NeoVeldrid.D3D11
             _mainSwapchain?.Dispose();
             _immediateContext.Dispose();
 
-            if (IsDebugEnabled)
+            if (_debugActive)
             {
                 // Release our device reference. If refCount > 0, leaked objects are keeping it alive.
                 ID3D11Device* pRawDevice = _device.Handle;

--- a/src/NeoVeldrid/GraphicsDevice.cs
+++ b/src/NeoVeldrid/GraphicsDevice.cs
@@ -58,6 +58,20 @@ namespace NeoVeldrid
         public abstract bool IsClipSpaceYInverted { get; }
 
         /// <summary>
+        /// Gets a value indicating whether debug mode was requested when this device was created, as specified by
+        /// <see cref="GraphicsDeviceOptions.Debug"/>. A true value does not guarantee that debugging is actually
+        /// active; see <see cref="IsDebugActive"/> for that.
+        /// </summary>
+        public bool IsDebugRequested { get; protected set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the graphics API's debug or validation facilities are actually active for
+        /// this device. Unlike <see cref="IsDebugRequested"/>, this requires the backend, driver, and any needed SDK or
+        /// validation layers to support and enable debugging, so it can be false even when debug mode was requested.
+        /// </summary>
+        public abstract bool IsDebugActive { get; }
+
+        /// <summary>
         /// Gets the <see cref="ResourceFactory"/> controlled by this instance.
         /// </summary>
         public abstract ResourceFactory ResourceFactory { get; }

--- a/src/NeoVeldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -42,6 +42,7 @@ namespace NeoVeldrid.OpenGL
         public GL GL { get; private set; }
         private OpenGLExtensions _extensions;
         private bool _isDepthRangeZeroToOne;
+        private bool _debugActive;
 
         // EXT_debug_marker (GLES extension for GPU profiling tools like Xcode GPU debugger).
         internal ExtDebugMarker _extDebugMarker;
@@ -105,6 +106,8 @@ namespace NeoVeldrid.OpenGL
 
         public override bool IsClipSpaceYInverted => false;
 
+        public override bool IsDebugActive => _debugActive;
+
         public override ResourceFactory ResourceFactory => _resourceFactory;
 
         public OpenGLExtensions Extensions => _extensions;
@@ -150,6 +153,7 @@ namespace NeoVeldrid.OpenGL
             uint height,
             bool loadFunctions)
         {
+            IsDebugRequested = options.Debug;
             _syncToVBlank = options.SyncToVerticalBlank;
             _glContext = platformInfo.OpenGLContextHandle;
             _makeCurrent = platformInfo.MakeCurrent;
@@ -253,7 +257,8 @@ namespace NeoVeldrid.OpenGL
             GL.BindVertexArray(_vao);
             CheckLastError();
 
-            if (options.Debug && (_extensions.KHR_Debug || _extensions.ARB_DebugOutput))
+            _debugActive = options.Debug && (_extensions.KHR_Debug || _extensions.ARB_DebugOutput);
+            if (_debugActive)
             {
                 EnableDebugCallback();
             }

--- a/src/NeoVeldrid/Vk/VkGraphicsDevice.cs
+++ b/src/NeoVeldrid/Vk/VkGraphicsDevice.cs
@@ -46,6 +46,7 @@ namespace NeoVeldrid.Vk
         private DebugReportCallbackEXT _debugCallbackHandle;
         private PfnDebugReportCallbackEXT _debugCallbackFunc;
         private bool _debugMarkerEnabled;
+        private bool _debugActive;
         private vkDebugMarkerSetObjectNameEXT_t _setObjectNameDelegate;
         private vkCmdDebugMarkerBeginEXT_t _markerBegin;
         private vkCmdDebugMarkerEndEXT_t _markerEnd;
@@ -96,6 +97,8 @@ namespace NeoVeldrid.Vk
 
         public override bool IsClipSpaceYInverted => !_standardClipYDirection;
 
+        public override bool IsDebugActive => _debugActive;
+
         public override Swapchain MainSwapchain => _mainSwapchain;
 
         public override GraphicsDeviceFeatures Features { get; }
@@ -139,6 +142,7 @@ namespace NeoVeldrid.Vk
         public VkGraphicsDevice(GraphicsDeviceOptions options, SwapchainDescription? scDesc, VulkanDeviceOptions vkOptions)
         {
             CreateInstance(options.Debug, vkOptions);
+            IsDebugRequested = options.Debug;
 
             SurfaceKHR surface = default;
             if (scDesc != null)
@@ -570,6 +574,7 @@ namespace NeoVeldrid.Vk
             {
                 if (availableInstanceExtensions.Contains(CommonStrings.VK_EXT_DEBUG_REPORT_EXTENSION_NAME))
                 {
+                    _debugActive = true;
                     debugReportExtensionAvailable = true;
                     instanceExtensions[instanceExtensionCount++] = CommonStrings.VK_EXT_DEBUG_REPORT_EXTENSION_NAME;
                 }

--- a/tests/NeoVeldrid.Tests/GraphicsDeviceTests.cs
+++ b/tests/NeoVeldrid.Tests/GraphicsDeviceTests.cs
@@ -1,0 +1,31 @@
+using Xunit;
+
+namespace NeoVeldrid.Tests
+{
+    public abstract class GraphicsDeviceTestBase_Debug<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
+    {
+        [Fact]
+        public void IsDebugRequested_ReflectsRequestedOption()
+        {
+            // Every test fixture creates its device with GraphicsDeviceOptions.Debug = true.
+            Assert.True(GD.IsDebugRequested);
+        }
+    }
+
+#if TEST_VULKAN
+    [Trait("Backend", "Vulkan")]
+    public class VulkanGraphicsDeviceTests : GraphicsDeviceTestBase_Debug<VulkanDeviceCreator> { }
+#endif
+#if TEST_D3D11
+    [Trait("Backend", "D3D11")]
+    public class D3D11GraphicsDeviceTests : GraphicsDeviceTestBase_Debug<D3D11DeviceCreator> { }
+#endif
+#if TEST_OPENGL
+    [Trait("Backend", "OpenGL")]
+    public class OpenGLGraphicsDeviceTests : GraphicsDeviceTestBase_Debug<OpenGLDeviceCreator> { }
+#endif
+#if TEST_OPENGLES
+    [Trait("Backend", "OpenGLES")]
+    public class OpenGLESGraphicsDeviceTests : GraphicsDeviceTestBase_Debug<OpenGLESDeviceCreator> { }
+#endif
+}


### PR DESCRIPTION
After a `GraphicsDevice` is created, there was no way to ask it whether debug was on. The `GraphicsDeviceOptions.Debug` flag is consumed during construction and then forgotten, so any code that wants to react to it (a diagnostics overlay, conditional validation, a "why aren't my errors showing up?" check) had to separately track the value it passed in.

This adds two read-only properties that answer two different questions:

- **`IsDebugRequested`**: did the caller ask for debug? Mirrors `GraphicsDeviceOptions.Debug`.
- **`IsDebugActive`**: are the graphics API's debug/validation facilities actually running? This can be `false` even when debug was requested, because the device silently falls back when the machinery isn't there: D3D11 without the SDK debug layers installed, Vulkan without validation layers, OpenGL on a context that doesn't expose `KHR_debug`/`ARB_debug_output`.

Keeping them separate is the whole point: it lets you tell "didn't ask" apart from "asked but couldn't", so you can, for example, warn the user that their validation layers are missing.

## What changed

- **Base `GraphicsDevice`** gets `IsDebugRequested` (stored) and `abstract IsDebugActive`.
- **D3D11** sets requested from the device creation flags, and active from the flags that survive the SDK-layer availability check. This folds in the old internal `IsDebugEnabled` property, which already meant exactly "active".
- **Vulkan** marks active when `VK_EXT_debug_report` is present, the condition under which the debug callback is installed.
- **OpenGL/GLES** mark active when debug was requested and the context exposes a debug extension, the same condition that gates installing the callback.

"Debug" rather than "Validation" in the names is deliberate. Validation is Vulkan's word, but OpenGL's facility is debug *output*, not validation, so "Debug" is the honest cross-backend term.

## Credit

Ported from TechPizza's veldrid2 fork: [`de8d14d`](https://github.com/veldrid2/veldrid2/commit/de8d14dc0824ec9adf5a6292efe24165ababeaac). The property names and the OpenGL "active means actually enabled" semantics are choices made here; veldrid2 named them `IsDebug`/`IsDriverDebug` and treated the GL flag as mere extension availability.