### PR TITLE
[Core] Add NeoVeldridMappedResourceException for mapped-resource errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 ### Added
 
 - [Core] `GraphicsDevice.IsDebugRequested` and `GraphicsDevice.IsDebugActive` properties to query whether debug mode was requested and whether the API's debug or validation facilities are actually active.
+- [Core] `NeoVeldridMappedResourceException` (a `NeoVeldridException` subtype) thrown for mapped-resource errors, carrying the offending `Resource`/`Subresource`, so callers can catch and inspect them specifically.
+
+### Changed
+
+- [OpenGL] Binding a currently-mapped buffer as a vertex or index buffer now throws instead of producing undefined behavior.
 
 ### Removed
 

--- a/src/NeoVeldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/NeoVeldrid/D3D11/D3D11GraphicsDevice.cs
@@ -391,7 +391,7 @@ namespace NeoVeldrid.D3D11
                 {
                     if (info.Mode != mode)
                     {
-                        throw new NeoVeldridException("The given resource was already mapped with a different MapMode.");
+                        throw NeoVeldridMappedResourceException.ConflictingMode(resource, subresource);
                     }
 
                     info.RefCount += 1;
@@ -460,7 +460,7 @@ namespace NeoVeldrid.D3D11
             {
                 if (!_mappedResources.TryGetValue(key, out MappedResourceInfo info))
                 {
-                    throw new NeoVeldridException($"The given resource ({resource}) is not mapped.");
+                    throw NeoVeldridMappedResourceException.NotMapped(resource, subresource);
                 }
 
                 info.RefCount -= 1;

--- a/src/NeoVeldrid/NeoVeldridMappedResourceException.cs
+++ b/src/NeoVeldrid/NeoVeldridMappedResourceException.cs
@@ -1,0 +1,53 @@
+namespace NeoVeldrid
+{
+    /// <summary>
+    /// Represents errors that occur while mapping a <see cref="DeviceBuffer"/> or <see cref="Texture"/> into
+    /// CPU-accessible memory, such as a failed map, a conflicting map mode, or using a resource that is currently mapped.
+    /// </summary>
+    public class NeoVeldridMappedResourceException : NeoVeldridException
+    {
+        /// <summary>
+        /// Gets the resource whose mapping state caused the error.
+        /// </summary>
+        public MappableResource Resource { get; }
+
+        /// <summary>
+        /// Gets the subresource involved in the error. This is 0 for buffers, which have no subresources.
+        /// </summary>
+        public uint Subresource { get; }
+
+        private NeoVeldridMappedResourceException(string message, MappableResource resource, uint subresource) : base(message)
+        {
+            Resource = resource;
+            Subresource = subresource;
+        }
+
+        internal static NeoVeldridMappedResourceException Mapped(MappableResource resource, uint subresource)
+        {
+            return new($"The {Describe(resource, subresource)} is mapped.", resource, subresource);
+        }
+
+        internal static NeoVeldridMappedResourceException NotMapped(MappableResource resource, uint subresource)
+        {
+            return new($"The {Describe(resource, subresource)} is not mapped.", resource, subresource);
+        }
+
+        internal static NeoVeldridMappedResourceException MapFailed(MappableResource resource, uint subresource)
+        {
+            return new($"Failed to map the {Describe(resource, subresource)}.", resource, subresource);
+        }
+
+        internal static NeoVeldridMappedResourceException ConflictingMode(MappableResource resource, uint subresource)
+        {
+            return new($"The {Describe(resource, subresource)} was already mapped with a different MapMode.", resource, subresource);
+        }
+
+        private static string Describe(MappableResource resource, uint subresource)
+        {
+            string kind = resource is Texture ? "texture" : "buffer";
+            string name = (resource as DeviceResource)?.Name;
+            string described = string.IsNullOrEmpty(name) ? kind : $"{kind} '{name}'";
+            return subresource == 0 ? described : $"{described} (subresource {subresource})";
+        }
+    }
+}

--- a/src/NeoVeldrid/OpenGL/OpenGLBuffer.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLBuffer.cs
@@ -25,6 +25,9 @@ namespace NeoVeldrid.OpenGL
 
         public bool Created { get; private set; }
 
+        // Denormalized here so the check is lock-free in the hot path.
+        internal bool IsMapped { get; set; }
+
         public override bool IsDisposed => _disposeRequested;
 
         public OpenGLBuffer(OpenGLGraphicsDevice gd, uint sizeInBytes, BufferUsage usage)

--- a/src/NeoVeldrid/OpenGL/OpenGLCommandList.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLCommandList.cs
@@ -114,6 +114,9 @@ namespace NeoVeldrid.OpenGL
 
         private protected override void SetIndexBufferCore(DeviceBuffer buffer, IndexFormat format, uint offset)
         {
+#if VALIDATE_USAGE
+            OpenGLGraphicsDevice.ThrowIfMapped(buffer);
+#endif
             _currentCommands.SetIndexBuffer(buffer, format, offset);
         }
 
@@ -139,6 +142,9 @@ namespace NeoVeldrid.OpenGL
 
         private protected override void SetVertexBufferCore(uint index, DeviceBuffer buffer, uint offset)
         {
+#if VALIDATE_USAGE
+            OpenGLGraphicsDevice.ThrowIfMapped(buffer);
+#endif
             _currentCommands.SetVertexBuffer(index, buffer, offset);
         }
 

--- a/src/NeoVeldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -577,7 +577,7 @@ namespace NeoVeldrid.OpenGL
                 {
                     if (info.Mode != mode)
                     {
-                        throw new NeoVeldridException("The given resource was already mapped with a different MapMode.");
+                        throw NeoVeldridMappedResourceException.ConflictingMode(resource, subresource);
                     }
 
                     info.RefCount += 1;
@@ -594,15 +594,18 @@ namespace NeoVeldrid.OpenGL
             _executionThread.Unmap(resource, subresource);
         }
 
+        internal static void ThrowIfMapped(DeviceBuffer buffer)
+        {
+            OpenGLBuffer glBuffer = Util.AssertSubtype<DeviceBuffer, OpenGLBuffer>(buffer);
+            if (glBuffer.IsMapped)
+            {
+                throw NeoVeldridMappedResourceException.Mapped(buffer, 0);
+            }
+        }
+
         private protected override void UpdateBufferCore(DeviceBuffer buffer, uint bufferOffsetInBytes, IntPtr source, uint sizeInBytes)
         {
-            lock (_mappedResourceLock)
-            {
-                if (_mappedResources.ContainsKey(new MappedResourceCacheKey(buffer, 0)))
-                {
-                    throw new NeoVeldridException("Cannot call UpdateBuffer on a currently-mapped Buffer.");
-                }
-            }
+            ThrowIfMapped(buffer);
             StagingBlock sb = _stagingMemoryPool.Stage(source, sizeInBytes);
             _executionThread.UpdateBuffer(buffer, bufferOffsetInBytes, sb);
         }
@@ -1093,6 +1096,7 @@ namespace NeoVeldrid.OpenGL
                             info.RefCount = 1;
                             info.Mode = mode;
                             _gd._mappedResources.Add(key, info);
+                            buffer.IsMapped = true;
                             result->Data = (IntPtr)mappedPtr;
                             result->DataSize = buffer.SizeInBytes;
                             result->RowPitch = 0;
@@ -1331,6 +1335,8 @@ namespace NeoVeldrid.OpenGL
                                 _gd.GL.UnmapBuffer(BufferTargetARB.CopyWriteBuffer);
                                 CheckLastError();
                             }
+
+                            buffer.IsMapped = false;
                         }
                         else
                         {
@@ -1394,7 +1400,7 @@ namespace NeoVeldrid.OpenGL
                 mre.Wait();
                 if (!mrp.Succeeded)
                 {
-                    throw new NeoVeldridException("Failed to map OpenGL resource.");
+                    throw NeoVeldridMappedResourceException.MapFailed(resource, subresource);
                 }
 
                 mre.Dispose();

--- a/src/NeoVeldrid/Vk/VkDeviceMemoryManager.cs
+++ b/src/NeoVeldrid/Vk/VkDeviceMemoryManager.cs
@@ -474,11 +474,10 @@ namespace NeoVeldrid.Vk
             }
         }
 
-        internal IntPtr Map(VkMemoryBlock memoryBlock)
+        internal IntPtr Map(VkMemoryBlock memoryBlock, out Result result)
         {
             void* ret;
-            Result result = _vk.MapMemory(_device, memoryBlock.DeviceMemory, memoryBlock.Offset, memoryBlock.Size, 0, &ret);
-            CheckResult(result);
+            result = _vk.MapMemory(_device, memoryBlock.DeviceMemory, memoryBlock.Offset, memoryBlock.Size, 0, &ret);
             return (IntPtr)ret;
         }
     }

--- a/src/NeoVeldrid/Vk/VkGraphicsDevice.cs
+++ b/src/NeoVeldrid/Vk/VkGraphicsDevice.cs
@@ -1026,7 +1026,12 @@ namespace NeoVeldrid.Vk
                 }
                 else
                 {
-                    mappedPtr = _memoryManager.Map(memoryBlock);
+                    mappedPtr = _memoryManager.Map(memoryBlock, out Result result);
+                    if (result == Result.ErrorMemoryMapFailed)
+                    {
+                        throw NeoVeldridMappedResourceException.MapFailed(resource, subresource);
+                    }
+                    CheckResult(result);
                 }
             }
 

--- a/tests/NeoVeldrid.Tests/BufferTests.cs
+++ b/tests/NeoVeldrid.Tests/BufferTests.cs
@@ -180,7 +180,7 @@ namespace NeoVeldrid.Tests
             DeviceBuffer buffer = RF.CreateBuffer(new BufferDescription(1024, BufferUsage.Staging));
             MappedResourceView<int> view = GD.Map<int>(buffer, MapMode.ReadWrite);
             int[] data = Enumerable.Range(0, 256).Select(i => 2 * i).ToArray();
-            Assert.Throws<NeoVeldridException>(() => GD.UpdateBuffer(buffer, 0, data));
+            Assert.Throws<NeoVeldridMappedResourceException>(() => GD.UpdateBuffer(buffer, 0, data));
         }
 
         [Fact]
@@ -207,7 +207,31 @@ namespace NeoVeldrid.Tests
             }
             DeviceBuffer buffer = RF.CreateBuffer(new BufferDescription(1024, BufferUsage.Staging));
             MappedResource map = GD.Map(buffer, MapMode.Read);
-            Assert.Throws<NeoVeldridException>(() => GD.Map(buffer, MapMode.Write));
+            var ex = Assert.Throws<NeoVeldridMappedResourceException>(() => GD.Map(buffer, MapMode.Write));
+            Assert.Same(buffer, ex.Resource);
+            Assert.Equal(0u, ex.Subresource);
+        }
+
+        [Fact]
+        public void BindMappedBuffer_Fails()
+        {
+            // The mapped-buffer pipeline check is OpenGL-only.
+            if (GD.BackendType != GraphicsBackend.OpenGL && GD.BackendType != GraphicsBackend.OpenGLES)
+            {
+                return;
+            }
+            DeviceBuffer buffer = RF.CreateBuffer(new BufferDescription(64, BufferUsage.VertexBuffer | BufferUsage.Dynamic));
+            CommandList cl = RF.CreateCommandList();
+            cl.Begin();
+            GD.Map(buffer, MapMode.Write);
+            try
+            {
+                Assert.Throws<NeoVeldridMappedResourceException>(() => cl.SetVertexBuffer(0, buffer));
+            }
+            finally
+            {
+                GD.Unmap(buffer);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Mapping a `DeviceBuffer` or `Texture` can fail in a few distinct ways: the resource is already mapped with a conflicting mode, you unmap something that isn't mapped, the driver refuses the map, or (on OpenGL) you bind a still-mapped buffer for drawing. All of these previously surfaced as a generic `NeoVeldridException`, indistinguishable from any other failure, so a caller couldn't single out the mapping case.

This adds `NeoVeldridMappedResourceException`, a `NeoVeldridException` subtype thrown for all of them. It's a subtype, so existing `catch (NeoVeldridException)` code is unaffected; code that wants to handle map errors specifically now can.

## What changed

- **New `NeoVeldridMappedResourceException`** carrying the offending `Resource` and `Subresource` as properties. It's built only through internal factories (one per failure kind), with no public constructor, so every instance describes a real resource and the type can't be created in a contentless state.
- **D3D11, Vulkan, and OpenGL** map / unmap / map-failure paths now throw the typed exception in place of the generic one.
- **OpenGL**: binding a currently-mapped buffer as a vertex or index buffer now throws, instead of silently feeding the GPU buffer contents that are undefined while mapped. The check is a lock-free flag read on the buffer (the mapped state is mirrored onto `OpenGLBuffer` under the existing map lock), so it stays cheap on the per-bind hot path and is gated behind the usual `VALIDATE_USAGE`.

## Messages

The message names the resource by its `Name` when one is set ("The buffer 'PlayerVertexBuffer' is mapped."), and falls back to the kind otherwise. The `Resource` property covers the unnamed case for debugger and programmatic inspection.

## Credit

Ported from @TechPizzaDev's veldrid2 fork: [`3698e94`](https://github.com/veldrid2/veldrid2/commit/3698e94cd2434b71323c972184fe5f96f32f88ec), [`060116d`](https://github.com/veldrid2/veldrid2/commit/060116dc5883e49c31eb39fdbb147e094512fb10), [`00a2f6a`](https://github.com/veldrid2/veldrid2/commit/00a2f6ac3913fc68a4dbb8e6f7d452725dc5b308), [`f89f84f`](https://github.com/veldrid2/veldrid2/commit/f89f84f872512b2efac76064156cad87b89da5ce). Differences from the source: the exception carries structured `Resource`/`Subresource` (veldrid2's was message-only), the OpenGL bind check reads a per-buffer flag rather than taking a lock and hashing a dictionary, and a few of veldrid2's worker-thread throws were left out where neo's deferred-GL threading model would surface them un-catchably.