### PR TITLE
[Core] Simplifying GraphicsDevice Creation

### DIFF
--- a/samples/common/SampleBase/BackendHelper.cs
+++ b/samples/common/SampleBase/BackendHelper.cs
@@ -25,7 +25,7 @@ namespace SampleBase
                         $"Unknown NEOVELDRID_BACKEND value: '{envBackend}'. Use: d3d11, vulkan, opengl, opengles")
                 };
             }
-            return NeoVeldridStartup.GetPlatformDefaultBackend();
+            return GraphicsDevice.GetPreferredBackend();
         }
     }
 }

--- a/samples/demos/NeoDemo/NeoDemo.cs
+++ b/samples/demos/NeoDemo/NeoDemo.cs
@@ -60,21 +60,10 @@ namespace NeoVeldrid.NeoDemo
 #if DEBUG
             gdOptions.Debug = true;
 #endif
-            string backendEnv = Environment.GetEnvironmentVariable("NEOVELDRID_BACKEND");
-            GraphicsBackend backend = string.IsNullOrEmpty(backendEnv)
-                ? NeoVeldridStartup.GetPlatformDefaultBackend()
-                : backendEnv.ToLowerInvariant() switch
-                {
-                    "d3d11" or "direct3d11" => GraphicsBackend.Direct3D11,
-                    "vulkan" or "vk" => GraphicsBackend.Vulkan,
-                    "opengl" or "gl" => GraphicsBackend.OpenGL,
-                    "opengles" or "gles" => GraphicsBackend.OpenGLES,
-                    _ => throw new InvalidOperationException($"Unknown NEOVELDRID_BACKEND: '{backendEnv}'")
-                };
             NeoVeldridStartup.CreateWindowAndGraphicsDevice(
                 windowCI,
                 gdOptions,
-                backend,
+                GraphicsDevice.GetPreferredBackend(),
                 out _window,
                 out _gd);
             _window.Resized += () => _windowResized = true;

--- a/samples/techniques/GettingStarted/Program.cs
+++ b/samples/techniques/GettingStarted/Program.cs
@@ -58,18 +58,8 @@ void main()
                 PreferDepthRangeZeroToOne = true
             };
 
-            string backendEnv = Environment.GetEnvironmentVariable("NEOVELDRID_BACKEND");
-            GraphicsBackend backend = string.IsNullOrEmpty(backendEnv)
-                ? NeoVeldridStartup.GetPlatformDefaultBackend()
-                : backendEnv.ToLowerInvariant() switch
-                {
-                    "d3d11" or "direct3d11" => GraphicsBackend.Direct3D11,
-                    "vulkan" or "vk" => GraphicsBackend.Vulkan,
-                    "opengl" or "gl" => GraphicsBackend.OpenGL,
-                    "opengles" or "gles" => GraphicsBackend.OpenGLES,
-                    _ => throw new InvalidOperationException($"Unknown NEOVELDRID_BACKEND: '{backendEnv}'")
-                };
-            NeoVeldridStartup.CreateWindowAndGraphicsDevice(windowCI, options, backend, out Sdl2Window window, out _graphicsDevice);
+            NeoVeldridStartup.CreateWindowAndGraphicsDevice(windowCI, options, GraphicsBackend.Preferred,
+                out Sdl2Window window, out _graphicsDevice);
             window.Title = $"{window.Title} ({_graphicsDevice.BackendType})";
 
             CreateResources();

--- a/src/NeoVeldrid.StartupUtilities/NeoVeldridStartup.cs
+++ b/src/NeoVeldrid.StartupUtilities/NeoVeldridStartup.cs
@@ -17,7 +17,7 @@ namespace NeoVeldrid.StartupUtilities
             => CreateWindowAndGraphicsDevice(
                 windowCI,
                 new GraphicsDeviceOptions(),
-                GetPlatformDefaultBackend(),
+                GraphicsDevice.GetPreferredBackend(),
                 out window,
                 out gd);
 
@@ -26,26 +26,29 @@ namespace NeoVeldrid.StartupUtilities
             GraphicsDeviceOptions deviceOptions,
             out Sdl2Window window,
             out GraphicsDevice gd)
-            => CreateWindowAndGraphicsDevice(windowCI, deviceOptions, GetPlatformDefaultBackend(), out window, out gd);
+            => CreateWindowAndGraphicsDevice(windowCI, deviceOptions, GraphicsDevice.GetPreferredBackend(), out window, out gd);
 
         public static void CreateWindowAndGraphicsDevice(
             WindowCreateInfo windowCI,
             GraphicsDeviceOptions deviceOptions,
-            GraphicsBackend preferredBackend,
+            GraphicsBackend backend,
             out Sdl2Window window,
             out GraphicsDevice gd)
         {
+            if (backend == GraphicsBackend.Preferred)
+                backend = GraphicsDevice.GetPreferredBackend();
+
             Sdl.Init(Silk.NET.SDL.Sdl.InitVideo);
 
 #if !EXCLUDE_OPENGL_BACKEND
-            if (preferredBackend == GraphicsBackend.OpenGL || preferredBackend == GraphicsBackend.OpenGLES)
+            if (backend == GraphicsBackend.OpenGL || backend == GraphicsBackend.OpenGLES)
             {
-                SetSDLGLContextAttributes(deviceOptions, preferredBackend);
+                SetSDLGLContextAttributes(deviceOptions, backend);
             }
 #endif
 
             window = CreateWindow(ref windowCI);
-            gd = CreateGraphicsDevice(window, deviceOptions, preferredBackend);
+            gd = CreateGraphicsDevice(window, deviceOptions, backend);
         }
 
         public static Sdl2Window CreateWindow(WindowCreateInfo windowCI) => CreateWindow(ref windowCI);
@@ -93,17 +96,20 @@ namespace NeoVeldrid.StartupUtilities
         }
 
         public static GraphicsDevice CreateGraphicsDevice(Sdl2Window window)
-            => CreateGraphicsDevice(window, new GraphicsDeviceOptions(), GetPlatformDefaultBackend());
+            => CreateGraphicsDevice(window, new GraphicsDeviceOptions(), GraphicsDevice.GetPreferredBackend());
         public static GraphicsDevice CreateGraphicsDevice(Sdl2Window window, GraphicsDeviceOptions options)
-            => CreateGraphicsDevice(window, options, GetPlatformDefaultBackend());
-        public static GraphicsDevice CreateGraphicsDevice(Sdl2Window window, GraphicsBackend preferredBackend)
-            => CreateGraphicsDevice(window, new GraphicsDeviceOptions(), preferredBackend);
+            => CreateGraphicsDevice(window, options, GraphicsDevice.GetPreferredBackend());
+        public static GraphicsDevice CreateGraphicsDevice(Sdl2Window window, GraphicsBackend backend)
+            => CreateGraphicsDevice(window, new GraphicsDeviceOptions(), backend);
         public static GraphicsDevice CreateGraphicsDevice(
             Sdl2Window window,
             GraphicsDeviceOptions options,
-            GraphicsBackend preferredBackend)
+            GraphicsBackend backend)
         {
-            switch (preferredBackend)
+            if (backend == GraphicsBackend.Preferred)
+                backend = GraphicsDevice.GetPreferredBackend();
+
+            switch (backend)
             {
                 case GraphicsBackend.Direct3D11:
 #if !EXCLUDE_D3D11_BACKEND
@@ -119,18 +125,18 @@ namespace NeoVeldrid.StartupUtilities
 #endif
                 case GraphicsBackend.OpenGL:
 #if !EXCLUDE_OPENGL_BACKEND
-                    return CreateDefaultOpenGLGraphicsDevice(options, window, preferredBackend);
+                    return CreateDefaultOpenGLGraphicsDevice(options, window, backend);
 #else
                     throw new NeoVeldridException("OpenGL support has not been included in this configuration of NeoVeldrid");
 #endif
                 case GraphicsBackend.OpenGLES:
 #if !EXCLUDE_OPENGL_BACKEND
-                    return CreateDefaultOpenGLGraphicsDevice(options, window, preferredBackend);
+                    return CreateDefaultOpenGLGraphicsDevice(options, window, backend);
 #else
                     throw new NeoVeldridException("OpenGL support has not been included in this configuration of NeoVeldrid");
 #endif
                 default:
-                    throw new NeoVeldridException("Invalid GraphicsBackend: " + preferredBackend);
+                    throw new NeoVeldridException("Invalid GraphicsBackend: " + backend);
             }
         }
 
@@ -157,44 +163,6 @@ namespace NeoVeldrid.StartupUtilities
                     return SwapchainSource.CreateNSWindow((nint)sysWmInfo.Info.Cocoa.Window);
                 default:
                     throw new PlatformNotSupportedException("Cannot create a SwapchainSource for " + sysWmInfo.Subsystem + ".");
-            }
-        }
-
-        public static GraphicsBackend GetPlatformDefaultBackend()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-#if !EXCLUDE_D3D11_BACKEND
-                return GraphicsBackend.Direct3D11;
-#elif !EXCLUDE_VULKAN_BACKEND
-                return GraphicsBackend.Vulkan;
-#elif !EXCLUDE_OPENGL_BACKEND
-                return GraphicsBackend.OpenGL;
-#else
-                throw new NeoVeldridException("No graphics backend is available. Enable at least one backend.");
-#endif
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-#if !EXCLUDE_VULKAN_BACKEND
-                return GraphicsBackend.Vulkan; // Via MoltenVK
-#elif !EXCLUDE_OPENGL_BACKEND
-                return GraphicsBackend.OpenGL;
-#else
-                throw new NeoVeldridException("No graphics backend is available. Enable at least one backend.");
-#endif
-            }
-            else
-            {
-#if !EXCLUDE_VULKAN_BACKEND
-                return GraphicsDevice.IsBackendSupported(GraphicsBackend.Vulkan)
-                    ? GraphicsBackend.Vulkan
-                    : GraphicsBackend.OpenGL;
-#elif !EXCLUDE_OPENGL_BACKEND
-                return GraphicsBackend.OpenGL;
-#else
-                throw new NeoVeldridException("No graphics backend is available. Enable at least one backend.");
-#endif
             }
         }
 

--- a/src/NeoVeldrid/GraphicsBackend.cs
+++ b/src/NeoVeldrid/GraphicsBackend.cs
@@ -6,17 +6,26 @@
     public enum GraphicsBackend : byte
     {
         /// <summary>
+        /// The preferred backend for the executing platform. If the environment variable NEOVELDRID_BACKEND is
+        /// set, the backend specified in that variable will be used.
+        /// </summary>
+        Preferred,
+
+        /// <summary>
         /// Direct3D 11.
         /// </summary>
         Direct3D11,
+
         /// <summary>
         /// Vulkan.
         /// </summary>
         Vulkan,
+
         /// <summary>
         /// OpenGL.
         /// </summary>
         OpenGL,
+
         /// <summary>
         /// OpenGL ES.
         /// </summary>

--- a/src/NeoVeldrid/GraphicsDevice.cs
+++ b/src/NeoVeldrid/GraphicsDevice.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -998,6 +998,90 @@ namespace NeoVeldrid
             }
         }
 
+        /// <summary>
+        /// Retrieves the <see cref="GraphicsBackend"/> that is preferred on the executing platform.
+        /// If the environment variable NEOVELDRID_BACKEND is set, the <see cref="GraphicsBackend"/>
+        /// specified in that variable will be used.
+        /// </summary>
+        /// <returns>The <see cref="GraphicsBackend"/> that is preferred on the executing platform.</returns>
+        public static GraphicsBackend GetPreferredBackend()
+        {
+            string envBackend = Environment.GetEnvironmentVariable("NEOVELDRID_BACKEND");
+            if (!string.IsNullOrEmpty(envBackend))
+            {
+                return envBackend.ToLowerInvariant() switch
+                {
+                    "d3d11" or "direct3d11" => GraphicsBackend.Direct3D11,
+                    "vulkan" or "vk" => GraphicsBackend.Vulkan,
+                    "opengl" or "gl" => GraphicsBackend.OpenGL,
+                    "opengles" or "gles" => GraphicsBackend.OpenGLES,
+                    _ => throw new InvalidOperationException(
+                        $"Unknown NEOVELDRID_BACKEND value: '{envBackend}'. Use: d3d11, vulkan, opengl, opengles")
+                };
+            }
+            else
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+#if !EXCLUDE_D3D11_BACKEND
+                    return GraphicsBackend.Direct3D11;
+#elif !EXCLUDE_VULKAN_BACKEND
+                return GraphicsBackend.Vulkan;
+#elif !EXCLUDE_OPENGL_BACKEND
+                return GraphicsBackend.OpenGL;
+#else
+                throw new NeoVeldridException("No graphics backend is available. Enable at least one backend.");
+#endif
+                }
+
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+#if !EXCLUDE_VULKAN_BACKEND
+                    return GraphicsBackend.Vulkan; // Via MoltenVK
+#elif !EXCLUDE_OPENGL_BACKEND
+                return GraphicsBackend.OpenGL;
+#else
+                throw new NeoVeldridException("No graphics backend is available. Enable at least one backend.");
+#endif
+                }
+
+                else
+                {
+#if !EXCLUDE_VULKAN_BACKEND
+                    return GraphicsDevice.IsBackendSupported(GraphicsBackend.Vulkan)
+                        ? GraphicsBackend.Vulkan
+                        : GraphicsBackend.OpenGL;
+#elif !EXCLUDE_OPENGL_BACKEND
+                return GraphicsBackend.OpenGL;
+#else
+                throw new NeoVeldridException("No graphics backend is available. Enable at least one backend.");
+#endif
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="GraphicsDevice"/> using the specified <see cref="GraphicsBackend"/>.
+        /// </summary>
+        /// <param name="options">Describes several common properties of the GraphicsDevice.</param>
+        /// <param name="backend">The <see cref="GraphicsBackend"/> that should be targeted during
+        /// <see cref="GraphicsDevice"/> creation.</param>
+        /// <returns>A new <see cref="GraphicsDevice"/> using the specified <see cref="GraphicsBackend"/>.</returns>
+        public static GraphicsDevice Create(GraphicsDeviceOptions options, GraphicsBackend backend = GraphicsBackend.Preferred)
+        {
+            if (backend == GraphicsBackend.Preferred)
+                backend = GetPreferredBackend();
+
+            if (backend == GraphicsBackend.Direct3D11)
+                return CreateD3D11(options);
+            else if (backend == GraphicsBackend.Vulkan)
+                return CreateVulkan(options);
+            else
+                return CreateOpenGL(options);
+
+            throw new NeoVeldridException("An unknown exception has occurred during graphics device creation!");
+        }
+
 #if !EXCLUDE_D3D11_BACKEND
         /// <summary>
         /// Creates a new <see cref="GraphicsDevice"/> using Direct3D 11.
@@ -1134,6 +1218,34 @@ namespace NeoVeldrid
 #endif
 
 #if !EXCLUDE_OPENGL_BACKEND
+        /// <summary>
+        /// Creates a new <see cref="GraphicsDevice"/> using OpenGL or OpenGL ES, with a main Swapchain.
+        /// </summary>
+        /// <param name="options">Describes several common properties of the GraphicsDevice.</param>
+        /// <returns>A new <see cref="GraphicsDevice"/> using the OpenGL or OpenGL ES API.</returns>
+        public static GraphicsDevice CreateOpenGL(GraphicsDeviceOptions options)
+        {
+            if (options.OpenGLPlatformInfo == null)
+                throw new NeoVeldridException("When using CreateOpenGL(GraphicsDeviceOptions), the value of" +
+                    "GraphicsDeviceOptions.OpenGLPlatformInfo cannot be null or empty.");
+
+            return CreateOpenGL(options, options.OpenGLPlatformInfo);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="GraphicsDevice"/> using OpenGL or OpenGL ES, with a main Swapchain.
+        /// </summary>
+        /// <param name="options">Describes several common properties of the GraphicsDevice.</param>
+        /// <param name="platformInfo">An <see cref="OpenGL.OpenGLPlatformInfo"/> object encapsulating necessary OpenGL context
+        /// information.</param>
+        /// <returns>A new <see cref="GraphicsDevice"/> using the OpenGL or OpenGL ES API.</returns>
+        public static GraphicsDevice CreateOpenGL(
+            GraphicsDeviceOptions options,
+            OpenGL.OpenGLPlatformInfo platformInfo)
+        {
+            return CreateOpenGL(options, platformInfo, platformInfo.Width, platformInfo.Height);
+        }
+
         /// <summary>
         /// Creates a new <see cref="GraphicsDevice"/> using OpenGL or OpenGL ES, with a main Swapchain.
         /// </summary>

--- a/src/NeoVeldrid/GraphicsDeviceOptions.cs
+++ b/src/NeoVeldrid/GraphicsDeviceOptions.cs
@@ -9,41 +9,54 @@
         /// Indicates whether the GraphicsDevice will support debug features, provided they are supported by the host system.
         /// </summary>
         public bool Debug;
+
         /// <summary>
         /// Indicates whether the Graphicsdevice will include a "main" Swapchain. If this value is true, then the GraphicsDevice
         /// must be created with one of the overloads that provides Swapchain source information.
         /// </summary>
         public bool HasMainSwapchain;
+
         /// <summary>
         /// An optional <see cref="PixelFormat"/> to be used for the depth buffer of the swapchain. If this value is null, then
         /// no depth buffer will be present on the swapchain.
         /// </summary>
         public PixelFormat? SwapchainDepthFormat;
+
         /// <summary>
         /// Indicates whether the main Swapchain will be synchronized to the window system's vertical refresh rate.
         /// </summary>
         public bool SyncToVerticalBlank;
+
         /// <summary>
         /// Specifies which model the rendering backend should use for binding resources. This can be overridden per-pipeline
         /// by specifying a value in <see cref="GraphicsPipelineDescription.ResourceBindingModel"/>.
         /// </summary>
         public ResourceBindingModel ResourceBindingModel;
+
         /// <summary>
         /// Indicates whether a 0-to-1 depth range mapping is preferred. For OpenGL, this is not the default, and is not available
         /// on all systems.
         /// </summary>
         public bool PreferDepthRangeZeroToOne;
+
         /// <summary>
         /// Indicates whether a bottom-to-top-increasing clip space Y direction is preferred. For Vulkan, this is not the
         /// default, and may not be available on all systems.
         /// </summary>
         public bool PreferStandardClipSpaceYDirection;
+
         /// <summary>
         /// Indicates whether the main Swapchain should use an sRGB format. This value is only used in cases where the properties
         /// of the main SwapChain are not explicitly specified with a <see cref="SwapchainDescription"/>. If they are, then the
         /// value of <see cref="SwapchainDescription.ColorSrgb"/> will supercede the value specified here.
         /// </summary>
         public bool SwapchainSrgbFormat;
+
+        /// <summary>
+        /// Encapsulates various pieces of OpenGL context, necessary for creating a <see cref="GraphicsDevice"/> using the OpenGL
+        /// API. This will only be used if <see cref="GraphicsBackend.OpenGL"/> is used in <see cref="GraphicsDevice"/> creation.
+        /// </summary>
+        public OpenGL.OpenGLPlatformInfo OpenGLPlatformInfo;
 
         /// <summary>
         /// Constructs a new GraphicsDeviceOptions for a device with no main Swapchain.
@@ -60,6 +73,7 @@
             PreferDepthRangeZeroToOne = false;
             PreferStandardClipSpaceYDirection = false;
             SwapchainSrgbFormat = false;
+            OpenGLPlatformInfo = null;
         }
 
         /// <summary>
@@ -81,6 +95,7 @@
             PreferDepthRangeZeroToOne = false;
             PreferStandardClipSpaceYDirection = false;
             SwapchainSrgbFormat = false;
+            OpenGLPlatformInfo = null;
         }
 
         /// <summary>
@@ -107,6 +122,7 @@
             PreferDepthRangeZeroToOne = false;
             PreferStandardClipSpaceYDirection = false;
             SwapchainSrgbFormat = false;
+            OpenGLPlatformInfo = null;
         }
 
         /// <summary>
@@ -136,6 +152,7 @@
             PreferDepthRangeZeroToOne = preferDepthRangeZeroToOne;
             PreferStandardClipSpaceYDirection = false;
             SwapchainSrgbFormat = false;
+            OpenGLPlatformInfo = null;
         }
 
         /// <summary>
@@ -168,6 +185,7 @@
             PreferDepthRangeZeroToOne = preferDepthRangeZeroToOne;
             PreferStandardClipSpaceYDirection = preferStandardClipSpaceYDirection;
             SwapchainSrgbFormat = false;
+            OpenGLPlatformInfo = null;
         }
 
         /// <summary>
@@ -205,6 +223,7 @@
             PreferDepthRangeZeroToOne = preferDepthRangeZeroToOne;
             PreferStandardClipSpaceYDirection = preferStandardClipSpaceYDirection;
             SwapchainSrgbFormat = swapchainSrgbFormat;
+            OpenGLPlatformInfo = null;
         }
     }
 }

--- a/src/NeoVeldrid/OpenGL/OpenGLPlatformInfo.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLPlatformInfo.cs
@@ -61,6 +61,16 @@ namespace NeoVeldrid.OpenGL
         public Action<uint, uint> ResizeSwapchain { get; }
 
         /// <summary>
+        /// The initial width of the window managing the OpenGL context.
+        /// </summary>
+        public uint Width { get; }
+
+        /// <summary>
+        /// The initial height of the window managing the OpenGL context.
+        /// </summary>
+        public uint Height { get; }
+
+        /// <summary>
         /// Constructs a new OpenGLPlatformInfo.
         /// </summary>
         /// <param name="openGLContextHandle">The OpenGL context handle.</param>
@@ -74,6 +84,8 @@ namespace NeoVeldrid.OpenGL
         /// context.</param>
         /// <param name="setSyncToVerticalBlank">A delegate which can be used to set the synchronization behavior of the OpenGL
         /// context.</param>
+        /// <param name="width">The initial width of the window managing the OpenGL context.</param>
+        /// <param name="height">The initial height of the window managing the OpenGL context.</param>
         public OpenGLPlatformInfo(
             IntPtr openGLContextHandle,
             Func<string, IntPtr> getProcAddress,
@@ -82,7 +94,9 @@ namespace NeoVeldrid.OpenGL
             Action clearCurrentContext,
             Action<IntPtr> deleteContext,
             Action swapBuffers,
-            Action<bool> setSyncToVerticalBlank)
+            Action<bool> setSyncToVerticalBlank,
+            uint width = 0,
+            uint height = 0)
         {
             OpenGLContextHandle = openGLContextHandle;
             GetProcAddress = getProcAddress;
@@ -92,6 +106,8 @@ namespace NeoVeldrid.OpenGL
             DeleteContext = deleteContext;
             SwapBuffers = swapBuffers;
             SetSyncToVerticalBlank = setSyncToVerticalBlank;
+            Width = width;
+            Height = height;
         }
 
         /// <summary>
@@ -112,6 +128,8 @@ namespace NeoVeldrid.OpenGL
         /// application Swapchain.</param>
         /// <param name="resizeSwapchain">A delegate which is invoked when the main Swapchain is resized. This may be null,
         /// in which case no special action is taken when the Swapchain is resized.</param>
+        /// <param name="width">The initial width of the window managing the OpenGL context.</param>
+        /// <param name="height">The initial height of the window managing the OpenGL context.</param>
         public OpenGLPlatformInfo(
             IntPtr openGLContextHandle,
             Func<string, IntPtr> getProcAddress,
@@ -122,7 +140,9 @@ namespace NeoVeldrid.OpenGL
             Action swapBuffers,
             Action<bool> setSyncToVerticalBlank,
             Action setSwapchainFramebuffer,
-            Action<uint, uint> resizeSwapchain)
+            Action<uint, uint> resizeSwapchain,
+            uint width = 0,
+            uint height = 0)
         {
             OpenGLContextHandle = openGLContextHandle;
             GetProcAddress = getProcAddress;
@@ -134,6 +154,8 @@ namespace NeoVeldrid.OpenGL
             SetSyncToVerticalBlank = setSyncToVerticalBlank;
             SetSwapchainFramebuffer = setSwapchainFramebuffer;
             ResizeSwapchain = resizeSwapchain;
+            Width = width;
+            Height = height;
         }
     }
 }


### PR DESCRIPTION
This pull request extends `GraphicsBackend` and `GraphicsDevice` to make device creation easier. The PR adds, refactors, and removes the following:

- **Adds "Preferred" option:** Adds "Preferred" as an option in `GraphicsBackend` and sets it to the value of 0, making it the default value. A new method to `GraphicsDevice` is also added that resolves the preferred backend. This works by first checking the debug environment variable, and if not, runs the same code as `NeoVeldridStartup.GetPlatformDefaultBackend()`.
- **Adds additional device creation methods:** Adds a general purpose creation method to `GraphicsDevice` and additional `CreateOpenGL` methods to facilitate this. Extends `GraphicsDeviceOptions` to contain a completely optional `OpenGLPlatformInfo` to make `CreateOpenGL` more compatible with other platform-specific device creation methods. Extends `OpenGLPlatformInfo` with `Width` and `Height` values that are given default values in all constructors. ***This is not a breaking change, no existing functionality was changed.***
- **Refactors startup utilities:** Refactors `NeoVeldridStartup` to use the new preferred backend method. ***This is a very minor breaking change.*** The original `NeoVeldridStartup.GetPlatformDefaultBackend()` has been removed and any reference to it has been adjusted to use the new method.