### PR TITLE
[SDL2] Fix Sdl2Window.Title returning empty until first set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 - [Core] Mobile-only `SwapchainSource.CreateAndroidSurface`, `SwapchainSource.CreateUIView`, and the `GraphicsDevice.CreateOpenGLES(GraphicsDeviceOptions, SwapchainDescription)` overload. NeoVeldrid targets desktop platforms only.
 
+### Fixed
+
+- [SDL2] `Sdl2Window.Title` now reflects the title the window was created with, instead of returning an empty string until it is next set.
+
 ### Internal
 
 - Removed dead Android and iOS code paths left over from the Silk.NET port.

--- a/src/NeoVeldrid.SDL2/Sdl2Window.cs
+++ b/src/NeoVeldrid.SDL2/Sdl2Window.cs
@@ -57,6 +57,7 @@ namespace NeoVeldrid.Sdl2
         {
             _sdl.SetHint("SDL_MOUSE_FOCUS_CLICKTHROUGH", "1");
             _threadedProcessing = threadedProcessing;
+            _cachedWindowTitle = title;
             if (threadedProcessing)
             {
                 using (ManualResetEvent mre = new ManualResetEvent(false))


### PR DESCRIPTION
`Sdl2Window.Title` read back empty until the title was next set, because the constructor handed the title to SDL but never initialized the value its getter returns. This initializes it at construction, so `Title` reflects what the window was created with.

## Failing case

```csharp
Sdl2Window window = NeoVeldridStartup.CreateWindow(new WindowCreateInfo { WindowTitle = "My Window" });

string title = window.Title;
// Before this PR: ""          (empty, until Title is set again)
// After:          "My Window"
```
