### PR TITLE
[D3D11] Fix use-after-free when disposing a shader after pipeline creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 ### Fixed
 
 - [SDL2] `Sdl2Window.Title` now reflects the title the window was created with, instead of returning an empty string until it is next set.
+- [D3D11] Disposing a `Shader` after creating a `Pipeline` from it no longer crashes the graphics device. This makes it behave like the other backends.
 
 ### Internal
 

--- a/src/NeoVeldrid/D3D11/D3D11Pipeline.cs
+++ b/src/NeoVeldrid/D3D11/D3D11Pipeline.cs
@@ -35,31 +35,39 @@ namespace NeoVeldrid.D3D11
             Shader[] stages = description.ShaderSet.Shaders;
             for (int i = 0; i < description.ShaderSet.Shaders.Length; i++)
             {
+                // AddRef each shader so the pipeline owns its own reference; the caller is then
+                // free to dispose the Shader without destroying the resource this pipeline binds.
                 if (stages[i].Stage == ShaderStages.Vertex)
                 {
                     D3D11Shader d3d11VertexShader = ((D3D11Shader)stages[i]);
                     VertexShader = (ID3D11VertexShader*)d3d11VertexShader.DeviceShader.Handle;
+                    VertexShader->AddRef();
                     vsBytecode = d3d11VertexShader.Bytecode;
                 }
                 if (stages[i].Stage == ShaderStages.Geometry)
                 {
                     GeometryShader = (ID3D11GeometryShader*)((D3D11Shader)stages[i]).DeviceShader.Handle;
+                    GeometryShader->AddRef();
                 }
                 if (stages[i].Stage == ShaderStages.TessellationControl)
                 {
                     HullShader = (ID3D11HullShader*)((D3D11Shader)stages[i]).DeviceShader.Handle;
+                    HullShader->AddRef();
                 }
                 if (stages[i].Stage == ShaderStages.TessellationEvaluation)
                 {
                     DomainShader = (ID3D11DomainShader*)((D3D11Shader)stages[i]).DeviceShader.Handle;
+                    DomainShader->AddRef();
                 }
                 if (stages[i].Stage == ShaderStages.Fragment)
                 {
                     PixelShader = (ID3D11PixelShader*)((D3D11Shader)stages[i]).DeviceShader.Handle;
+                    PixelShader->AddRef();
                 }
                 if (stages[i].Stage == ShaderStages.Compute)
                 {
                     ComputeShader = (ID3D11ComputeShader*)((D3D11Shader)stages[i]).DeviceShader.Handle;
+                    ComputeShader->AddRef();
                 }
             }
 
@@ -112,6 +120,7 @@ namespace NeoVeldrid.D3D11
         {
             IsComputePipeline = true;
             ComputeShader = (ID3D11ComputeShader*)((D3D11Shader)description.ComputeShader).DeviceShader.Handle;
+            ComputeShader->AddRef();
             ResourceLayout[] genericLayouts = description.ResourceLayouts;
             ResourceLayouts = new D3D11ResourceLayout[genericLayouts.Length];
             for (int i = 0; i < ResourceLayouts.Length; i++)
@@ -130,7 +139,16 @@ namespace NeoVeldrid.D3D11
 
         public override void Dispose()
         {
-            _disposed = true;
+            if (!_disposed)
+            {
+                if (VertexShader != null) VertexShader->Release();
+                if (GeometryShader != null) GeometryShader->Release();
+                if (HullShader != null) HullShader->Release();
+                if (DomainShader != null) DomainShader->Release();
+                if (PixelShader != null) PixelShader->Release();
+                if (ComputeShader != null) ComputeShader->Release();
+                _disposed = true;
+            }
         }
     }
 }

--- a/tests/NeoVeldrid.Tests/DisposalTests.cs
+++ b/tests/NeoVeldrid.Tests/DisposalTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace NeoVeldrid.Tests
@@ -93,6 +96,76 @@ namespace NeoVeldrid.Tests
             Assert.True(shaders[0].IsDisposed);
             shaders[1].Dispose();
             Assert.True(shaders[1].IsDisposed);
+        }
+
+        // Contract for every backend: a Pipeline keeps its shaders alive for its own lifetime,
+        // so disposing the Shader objects after the Pipeline is built leaves the Pipeline fully
+        // usable. The backends satisfy this differently (Vulkan consumes the shader module at
+        // pipeline creation, D3D11 must hold a COM reference, OpenGL defers shader deletion), but
+        // the observable behavior must be identical: bind the pipeline and render after the
+        // shaders are gone, and the output is still correct.
+        [Fact]
+        public void DisposeShaders_AfterPipelineCreation_PipelineStillRenders()
+        {
+            const uint width = 4;
+            const uint height = 4;
+            using Texture output = RF.CreateTexture(TextureDescription.Texture2D(
+                width, height, 1, 1, PixelFormat.R32_G32_B32_A32_Float, TextureUsage.RenderTarget));
+            using Framebuffer framebuffer = RF.CreateFramebuffer(new FramebufferDescription(null, output));
+
+            float yMod = GD.IsClipSpaceYInverted ? -1.0f : 1.0f;
+            ColoredVertex[] vertices =
+            {
+                new ColoredVertex { Position = new Vector2(-1, 1 * yMod), Color = Vector4.One },
+                new ColoredVertex { Position = new Vector2(1, 1 * yMod), Color = Vector4.One },
+                new ColoredVertex { Position = new Vector2(-1, -1 * yMod), Color = Vector4.One },
+                new ColoredVertex { Position = new Vector2(1, -1 * yMod), Color = Vector4.One },
+            };
+            uint vertexSize = (uint)Unsafe.SizeOf<ColoredVertex>();
+            using DeviceBuffer buffer = RF.CreateBuffer(new BufferDescription(
+                vertexSize * (uint)vertices.Length, BufferUsage.StructuredBufferReadOnly, vertexSize));
+            GD.UpdateBuffer(buffer, 0, vertices);
+
+            using ResourceLayout graphicsLayout = RF.CreateResourceLayout(new ResourceLayoutDescription(
+                new ResourceLayoutElementDescription("InputVertices", ResourceKind.StructuredBufferReadOnly, ShaderStages.Vertex)));
+            using ResourceSet graphicsSet = RF.CreateResourceSet(new ResourceSetDescription(graphicsLayout, buffer));
+
+            Shader[] shaders = TestShaders.LoadVertexFragment(RF, "ColoredQuadRenderer");
+            using Pipeline pipeline = RF.CreateGraphicsPipeline(new GraphicsPipelineDescription(
+                BlendStateDescription.SingleOverrideBlend,
+                DepthStencilStateDescription.Disabled,
+                RasterizerStateDescription.Default,
+                PrimitiveTopology.TriangleStrip,
+                new ShaderSetDescription(Array.Empty<VertexLayoutDescription>(), shaders),
+                graphicsLayout,
+                framebuffer.OutputDescription));
+
+            // Dispose the shaders while the pipeline that was built from them is still alive.
+            foreach (Shader shader in shaders)
+            {
+                shader.Dispose();
+                Assert.True(shader.IsDisposed);
+            }
+
+            using CommandList cl = RF.CreateCommandList();
+            cl.Begin();
+            cl.SetFramebuffer(framebuffer);
+            cl.ClearColorTarget(0, RgbaFloat.Clear);
+            cl.SetPipeline(pipeline);
+            cl.SetGraphicsResourceSet(0, graphicsSet);
+            cl.Draw((uint)vertices.Length);
+            cl.End();
+            GD.SubmitCommands(cl);
+            GD.WaitForIdle();
+
+            using Texture readback = GetReadback(output);
+            MappedResourceView<RgbaFloat> readView = GD.Map<RgbaFloat>(readback, MapMode.Read);
+            for (uint y = 0; y < height; y++)
+                for (uint x = 0; x < width; x++)
+                {
+                    Assert.Equal(new RgbaFloat(1, 1, 1, 1), readView[x, y]);
+                }
+            GD.Unmap(readback);
         }
 
         [Fact]


### PR DESCRIPTION
A `D3D11Pipeline` copied the raw COM pointers of its shaders without taking a reference on them. Disposing a `Shader` after building a `Pipeline` from it then released the underlying shader object, leaving the pipeline holding dangling pointers. The next `SetPipeline` fed those freed pointers to `VSSetShader`/`PSSetShader`, a use-after-free that corrupted the device (surfacing as `DXGI_ERROR_DEVICE_REMOVED`, and under heavier workloads as a hard driver crash).

The fix is small: the pipeline now `AddRef`s each shader it captures in its constructors and `Release`s them in a guarded `Dispose()`, so it owns its shaders for its own lifetime. This matches the adopt-a-handle idiom already used in `D3D11Texture`.

## Why only D3D11

This is a write-once-run-everywhere gap. The same call sequence is already safe on the other backends:

- **Vulkan** bakes the shader module into the pipeline at creation, so the `Shader` is no longer needed afterward.
- **OpenGL** keeps a managed reference to its shaders and defers their deletion.
- **D3D11** was the only backend holding a live raw handle to a separately-owned GPU object without a reference on it.

So code that disposed its shaders right after building pipelines ran fine on two backends and hard-crashed on the third. Now all three behave identically.

## Failing case

```csharp
Shader[] shaders = /* vertex + fragment */;
Pipeline pipeline = factory.CreateGraphicsPipeline(/* ..., */ shaders);

foreach (Shader s in shaders) s.Dispose();   // legal once the pipeline is built

commandList.SetPipeline(pipeline);           // before: device removed / crash on D3D11
                                             // after:  renders correctly everywhere
```

## Test

A backend-generic disposal test in `DisposalTestBase<T>` renders through a pipeline after disposing its shaders and reads back the result, so the harness runs it on all four backends. It was green on Vulkan, OpenGL, and OpenGL ES and red on D3D11 before this change.

## Upstream

Upstream Veldrid has the same structural borrow, but its Vortice bindings wrap the shader in a managed COM object, so the failure there tends to be a managed exception rather than a native device crash. The Silk.NET port replaced that wrapper with a raw pointer, which removed the cushion. This addresses it at the source by giving the pipeline real ownership of its shaders.