### PR TITLE
[Core] Throw when binding a Framebuffer or ResourceSet that references a disposed resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 - [Core] `GraphicsDevice.IsDebugRequested` and `GraphicsDevice.IsDebugActive` properties to query whether debug mode was requested and whether the API's debug or validation facilities are actually active.
 - [Core] `NeoVeldridMappedResourceException` (a `NeoVeldridException` subtype) thrown for mapped-resource errors, carrying the offending `Resource`/`Subresource`, so callers can catch and inspect them specifically.
+- [Core] `NeoVeldridDisposedResourceException` (a `NeoVeldridException` subtype) thrown when a `Framebuffer` or `ResourceSet` references a disposed resource, carrying the offending `Resource` so callers can catch and inspect it specifically.
 
 ### Changed
 
 - [OpenGL] Binding a currently-mapped buffer as a vertex or index buffer now throws instead of producing undefined behavior.
+- [Core] Using a `Framebuffer` or `ResourceSet` that references a disposed resource now throws instead of producing undefined behavior.
 
 ### Removed
 

--- a/src/NeoVeldrid/BindableResource.cs
+++ b/src/NeoVeldrid/BindableResource.cs
@@ -5,5 +5,12 @@
     /// See <see cref="DeviceBuffer"/>, <see cref="DeviceBufferRange"/>, <see cref="Texture"/>, <see cref="TextureView"/>
     /// and <see cref="Sampler"/>.
     /// </summary>
-    public interface BindableResource { }
+    public interface BindableResource
+    {
+        /// <summary>
+        /// Whether this resource can currently be bound. Becomes <see langword="false"/> once it, or a resource it
+        /// references, has been disposed.
+        /// </summary>
+        internal bool IsBindable { get; }
+    }
 }

--- a/src/NeoVeldrid/Buffer.cs
+++ b/src/NeoVeldrid/Buffer.cs
@@ -30,6 +30,8 @@ namespace NeoVeldrid
         /// </summary>
         public abstract bool IsDisposed { get; }
 
+        bool BindableResource.IsBindable => !IsDisposed;
+
         /// <summary>
         /// Frees unmanaged device resources controlled by this instance.
         /// </summary>

--- a/src/NeoVeldrid/CommandList.cs
+++ b/src/NeoVeldrid/CommandList.cs
@@ -272,6 +272,7 @@ namespace NeoVeldrid
                 }
             }
 
+            ValidateResourceSetNotDisposed(slot, rs);
 #endif
             SetGraphicsResourceSetCore(slot, rs, dynamicOffsetsCount, ref dynamicOffsets);
         }
@@ -354,6 +355,7 @@ namespace NeoVeldrid
                         $"Failed to bind ResourceSet to slot {slot}. Resource element {i} was of the incorrect type. The bound Pipeline expects {pipelineKind}, but the ResourceSet contained {setKind}.");
                 }
             }
+            ValidateResourceSetNotDisposed(slot, rs);
 #endif
             SetComputeResourceSetCore(slot, rs, dynamicOffsetsCount, ref dynamicOffsets);
         }
@@ -367,6 +369,20 @@ namespace NeoVeldrid
         /// <param name="dynamicOffsets"></param>
         private protected abstract void SetComputeResourceSetCore(uint slot, ResourceSet set, uint dynamicOffsetsCount, ref uint dynamicOffsets);
 
+#if VALIDATE_USAGE
+        private static void ValidateResourceSetNotDisposed(uint slot, ResourceSet rs)
+        {
+            BindableResource[] resources = rs.Resources;
+            for (int i = 0; i < resources.Length; i++)
+            {
+                if (!resources[i].IsBindable)
+                {
+                    throw NeoVeldridDisposedResourceException.ResourceSetElement(resources[i], slot, i);
+                }
+            }
+        }
+#endif
+
         /// <summary>
         /// Sets the active <see cref="Framebuffer"/> which will be rendered to.
         /// When drawing, the active <see cref="Framebuffer"/> must be compatible with the active <see cref="Pipeline"/>.
@@ -375,6 +391,7 @@ namespace NeoVeldrid
         /// <param name="fb">The new <see cref="Framebuffer"/>.</param>
         public void SetFramebuffer(Framebuffer fb)
         {
+            ValidateFramebufferTargetsNotDisposed(fb);
             if (_framebuffer != fb)
             {
                 _framebuffer = fb;
@@ -389,6 +406,24 @@ namespace NeoVeldrid
         /// </summary>
         /// <param name="fb"></param>
         private protected abstract void SetFramebufferCore(Framebuffer fb);
+
+        [Conditional("VALIDATE_USAGE")]
+        private static void ValidateFramebufferTargetsNotDisposed(Framebuffer fb)
+        {
+            for (int i = 0; i < fb.ColorTargets.Count; i++)
+            {
+                Texture target = fb.ColorTargets[i].Target;
+                if (target.IsDisposed)
+                {
+                    throw NeoVeldridDisposedResourceException.FramebufferColorTarget(target, i);
+                }
+            }
+
+            if (fb.DepthTarget is FramebufferAttachment depth && depth.Target.IsDisposed)
+            {
+                throw NeoVeldridDisposedResourceException.FramebufferDepthTarget(depth.Target);
+            }
+        }
 
         /// <summary>
         /// Clears the color target at the given index of the active <see cref="Framebuffer"/>.

--- a/src/NeoVeldrid/DeviceBufferRange.cs
+++ b/src/NeoVeldrid/DeviceBufferRange.cs
@@ -35,6 +35,8 @@ namespace NeoVeldrid
             SizeInBytes = sizeInBytes;
         }
 
+        readonly bool BindableResource.IsBindable => Buffer != null && !Buffer.IsDisposed;
+
         /// <summary>
         /// Element-wise equality.
         /// </summary>

--- a/src/NeoVeldrid/NeoVeldridDisposedResourceException.cs
+++ b/src/NeoVeldrid/NeoVeldridDisposedResourceException.cs
@@ -1,0 +1,34 @@
+namespace NeoVeldrid
+{
+    /// <summary>
+    /// Thrown when a <see cref="Framebuffer"/> or <see cref="ResourceSet"/> is used after a resource it references has
+    /// been disposed.
+    /// </summary>
+    public class NeoVeldridDisposedResourceException : NeoVeldridException
+    {
+        /// <summary>
+        /// Gets the bound resource that caused the error: one that has been disposed, or that references a disposed resource.
+        /// </summary>
+        public BindableResource Resource { get; }
+
+        private NeoVeldridDisposedResourceException(string message, BindableResource resource) : base(message)
+        {
+            Resource = resource;
+        }
+
+        internal static NeoVeldridDisposedResourceException FramebufferColorTarget(BindableResource resource, int index)
+        {
+            return new($"The {Describe(resource)} bound as color target {index} of the Framebuffer has been disposed.", resource);
+        }
+
+        internal static NeoVeldridDisposedResourceException FramebufferDepthTarget(BindableResource resource)
+        {
+            return new($"The {Describe(resource)} bound as the depth target of the Framebuffer has been disposed.", resource);
+        }
+
+        internal static NeoVeldridDisposedResourceException ResourceSetElement(BindableResource resource, uint slot, int element)
+        {
+            return new($"The {Describe(resource)} bound at element {element} of the ResourceSet in slot {slot} has been disposed or references a disposed resource.", resource);
+        }
+    }
+}

--- a/src/NeoVeldrid/NeoVeldridException.cs
+++ b/src/NeoVeldrid/NeoVeldridException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace NeoVeldrid
 {
@@ -29,6 +29,28 @@ namespace NeoVeldrid
         /// <param name="innerException">The inner exception.</param>
         public NeoVeldridException(string message, Exception innerException) : base(message, innerException)
         {
+        }
+
+        internal static string Describe(BindableResource resource)
+        {
+            // A DeviceBufferRange is the one bindable that isn't a DeviceResource; describe it by its buffer.
+            return resource is DeviceBufferRange range
+                ? Describe((DeviceResource)range.Buffer)
+                : Describe(resource as DeviceResource);
+        }
+
+        internal static string Describe(DeviceResource resource)
+        {
+            string kind = resource switch
+            {
+                Texture => nameof(Texture),
+                TextureView => nameof(TextureView),
+                DeviceBuffer => nameof(DeviceBuffer),
+                Sampler => nameof(Sampler),
+                _ => "resource",
+            };
+            string name = resource?.Name;
+            return string.IsNullOrEmpty(name) ? kind : $"{kind} '{name}'";
         }
     }
 }

--- a/src/NeoVeldrid/Sampler.cs
+++ b/src/NeoVeldrid/Sampler.cs
@@ -19,6 +19,8 @@ namespace NeoVeldrid
         /// </summary>
         public abstract bool IsDisposed { get; }
 
+        bool BindableResource.IsBindable => !IsDisposed;
+
         /// <summary>
         /// Frees unmanaged device resources controlled by this instance.
         /// </summary>

--- a/src/NeoVeldrid/Texture.cs
+++ b/src/NeoVeldrid/Texture.cs
@@ -70,6 +70,8 @@ namespace NeoVeldrid
         /// </summary>
         public abstract bool IsDisposed { get; }
 
+        bool BindableResource.IsBindable => !IsDisposed;
+
         internal TextureView GetFullTextureView(GraphicsDevice gd)
         {
             lock (_fullTextureViewLock)

--- a/src/NeoVeldrid/TextureView.cs
+++ b/src/NeoVeldrid/TextureView.cs
@@ -55,6 +55,8 @@ namespace NeoVeldrid
         /// </summary>
         public abstract bool IsDisposed { get; }
 
+        bool BindableResource.IsBindable => !IsDisposed && !Target.IsDisposed;
+
         /// <summary>
         /// Frees unmanaged device resources controlled by this instance.
         /// </summary>

--- a/tests/NeoVeldrid.Tests/DisposalTests.cs
+++ b/tests/NeoVeldrid.Tests/DisposalTests.cs
@@ -168,6 +168,124 @@ namespace NeoVeldrid.Tests
             GD.Unmap(readback);
         }
 
+        // Contract for every backend: a Texture must not be disposed while a Framebuffer that
+        // targets it is still in use. Using such a Framebuffer is caught and reported the same way
+        // on every backend (D3D11 would otherwise silently tolerate it because the runtime keeps
+        // the resource alive through the render-target view, while Vulkan and OpenGL destroy it).
+        [Fact]
+        public void UseFramebuffer_AfterColorTargetDisposed_Throws()
+        {
+            Texture target = RF.CreateTexture(TextureDescription.Texture2D(
+                4, 4, 1, 1, PixelFormat.R8_G8_B8_A8_UNorm, TextureUsage.RenderTarget));
+            Framebuffer framebuffer = RF.CreateFramebuffer(new FramebufferDescription(null, target));
+
+            GD.WaitForIdle(); // Required currently by Vulkan backend.
+            target.Dispose();
+            Assert.True(target.IsDisposed);
+
+            CommandList cl = RF.CreateCommandList();
+            cl.Begin();
+            var ex = Assert.Throws<NeoVeldridDisposedResourceException>(() => cl.SetFramebuffer(framebuffer));
+            Assert.Same(target, ex.Resource);
+        }
+
+        // The same contract through a TextureView: a Texture must not be disposed while a ResourceSet
+        // binds a view of it. D3D11 keeps the resource alive through the view's SRV and would
+        // otherwise sample a logically-dead texture; Vulkan and OpenGL destroy it outright.
+        [Fact]
+        public void BindResourceSet_AfterSampledTextureDisposed_Throws()
+        {
+            Texture sampled = RF.CreateTexture(TextureDescription.Texture2D(
+                4, 4, 1, 1, PixelFormat.R8_G8_B8_A8_UNorm, TextureUsage.Sampled));
+            TextureView view = RF.CreateTextureView(sampled);
+
+            ResourceLayout layout = RF.CreateResourceLayout(new ResourceLayoutDescription(
+                new ResourceLayoutElementDescription("Input", ResourceKind.TextureReadOnly, ShaderStages.Fragment),
+                new ResourceLayoutElementDescription("InputSampler", ResourceKind.Sampler, ShaderStages.Fragment)));
+            ResourceSet set = RF.CreateResourceSet(new ResourceSetDescription(layout, view, GD.PointSampler));
+
+            Pipeline pipeline = RF.CreateGraphicsPipeline(new GraphicsPipelineDescription(
+                BlendStateDescription.SingleOverrideBlend,
+                DepthStencilStateDescription.Disabled,
+                RasterizerStateDescription.CullNone,
+                PrimitiveTopology.TriangleStrip,
+                new ShaderSetDescription(Array.Empty<VertexLayoutDescription>(), TestShaders.LoadVertexFragment(RF, "FullScreenBlit")),
+                layout,
+                new OutputDescription(null, new OutputAttachmentDescription(PixelFormat.R8_G8_B8_A8_UNorm))));
+
+            GD.WaitForIdle(); // Required currently by Vulkan backend.
+            sampled.Dispose();
+            Assert.True(sampled.IsDisposed);
+
+            CommandList cl = RF.CreateCommandList();
+            cl.Begin();
+            cl.SetPipeline(pipeline);
+            var ex = Assert.Throws<NeoVeldridDisposedResourceException>(() => cl.SetGraphicsResourceSet(0, set));
+            Assert.Same(view, ex.Resource);
+        }
+
+        [Fact]
+        public void BindResourceSet_AfterBufferDisposed_Throws()
+        {
+            DeviceBuffer buffer = RF.CreateBuffer(new BufferDescription(64, BufferUsage.StructuredBufferReadOnly, 16));
+
+            ResourceLayout layout = RF.CreateResourceLayout(new ResourceLayoutDescription(
+                new ResourceLayoutElementDescription("InputVertices", ResourceKind.StructuredBufferReadOnly, ShaderStages.Vertex)));
+            ResourceSet set = RF.CreateResourceSet(new ResourceSetDescription(layout, buffer));
+
+            Pipeline pipeline = RF.CreateGraphicsPipeline(new GraphicsPipelineDescription(
+                BlendStateDescription.SingleOverrideBlend,
+                DepthStencilStateDescription.Disabled,
+                RasterizerStateDescription.Default,
+                PrimitiveTopology.TriangleStrip,
+                new ShaderSetDescription(Array.Empty<VertexLayoutDescription>(), TestShaders.LoadVertexFragment(RF, "ColoredQuadRenderer")),
+                layout,
+                new OutputDescription(null, new OutputAttachmentDescription(PixelFormat.R8_G8_B8_A8_UNorm))));
+
+            GD.WaitForIdle(); // Required currently by Vulkan backend.
+            buffer.Dispose();
+            Assert.True(buffer.IsDisposed);
+
+            CommandList cl = RF.CreateCommandList();
+            cl.Begin();
+            cl.SetPipeline(pipeline);
+            var ex = Assert.Throws<NeoVeldridDisposedResourceException>(() => cl.SetGraphicsResourceSet(0, set));
+            Assert.Same(buffer, ex.Resource);
+        }
+
+        [Fact]
+        public void BindResourceSet_AfterSamplerDisposed_Throws()
+        {
+            Texture sampled = RF.CreateTexture(TextureDescription.Texture2D(
+                4, 4, 1, 1, PixelFormat.R8_G8_B8_A8_UNorm, TextureUsage.Sampled));
+            TextureView view = RF.CreateTextureView(sampled);
+            Sampler sampler = RF.CreateSampler(SamplerDescription.Point);
+
+            ResourceLayout layout = RF.CreateResourceLayout(new ResourceLayoutDescription(
+                new ResourceLayoutElementDescription("Input", ResourceKind.TextureReadOnly, ShaderStages.Fragment),
+                new ResourceLayoutElementDescription("InputSampler", ResourceKind.Sampler, ShaderStages.Fragment)));
+            ResourceSet set = RF.CreateResourceSet(new ResourceSetDescription(layout, view, sampler));
+
+            Pipeline pipeline = RF.CreateGraphicsPipeline(new GraphicsPipelineDescription(
+                BlendStateDescription.SingleOverrideBlend,
+                DepthStencilStateDescription.Disabled,
+                RasterizerStateDescription.CullNone,
+                PrimitiveTopology.TriangleStrip,
+                new ShaderSetDescription(Array.Empty<VertexLayoutDescription>(), TestShaders.LoadVertexFragment(RF, "FullScreenBlit")),
+                layout,
+                new OutputDescription(null, new OutputAttachmentDescription(PixelFormat.R8_G8_B8_A8_UNorm))));
+
+            GD.WaitForIdle(); // Required currently by Vulkan backend.
+            sampler.Dispose();
+            Assert.True(sampler.IsDisposed);
+
+            CommandList cl = RF.CreateCommandList();
+            cl.Begin();
+            cl.SetPipeline(pipeline);
+            var ex = Assert.Throws<NeoVeldridDisposedResourceException>(() => cl.SetGraphicsResourceSet(0, set));
+            Assert.Same(sampler, ex.Resource);
+        }
+
         [Fact]
         public void Dispose_ResourceSet()
         {


### PR DESCRIPTION
Binding a `Framebuffer` or `ResourceSet` that references a disposed resource was undefined behavior, and it behaved differently on every backend. This adds a uniform check that throws a clear, typed exception instead.

## Why it needed catching

The failure was backend-specific in a way that makes it a write-once-run-everywhere trap:

- **D3D11** silently tolerated it. Creating a view (SRV/RTV) makes the runtime take its own reference on the underlying texture, so disposing the texture left the GPU object alive and rendering "worked".
- **Vulkan and OpenGL** destroy the resource immediately, so the same code sampled or rendered into freed memory.

So a program that disposed a texture while keeping a framebuffer or resource set built from it ran fine on one backend and corrupted the device on the others.

## What it catches

In `VALIDATE_USAGE` builds (the default), using a command list now throws `NeoVeldridDisposedResourceException` when:

- a `Framebuffer`'s color or depth target `Texture` has been disposed, or
- a `ResourceSet` binds a resource that has been disposed, directly (a `Texture`, `DeviceBuffer`, `Sampler`, or the buffer behind a `DeviceBufferRange`) or indirectly (the `Texture` behind a still-live `TextureView`).

That last case is the subtle one: when you dispose a texture but keep a view of it, the *view* itself is still alive, so the check has to look through to its target. The exception carries the offending `BindableResource` so callers can catch and inspect it.

## How it works

The liveness question lives on `BindableResource` as an internal `IsBindable`, with each binding type answering for itself (a `TextureView` also checks its target, a `DeviceBufferRange` checks its buffer). The per-bind hot path is then a single virtual call rather than a type switch. The checks sit in the shared `CommandList` base, above the per-backend code, so every backend throws the same exception at the same point by construction.