### PR TITLE
[Core] Add GraphicsDevice.GetAvailableBackend()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 - [Core] `GraphicsDevice.IsDebugRequested` and `GraphicsDevice.IsDebugActive` properties to query whether debug mode was requested and whether the API's debug or validation facilities are actually active.
 - [Core] `NeoVeldridMappedResourceException` (a `NeoVeldridException` subtype) thrown for mapped-resource errors, carrying the offending `Resource`/`Subresource`, so callers can catch and inspect them specifically.
 - [Core] `NeoVeldridDisposedResourceException` (a `NeoVeldridException` subtype) thrown when a `Framebuffer` or `ResourceSet` references a disposed resource, carrying the offending `Resource` so callers can catch and inspect it specifically.
+- [Core] `GraphicsDevice.GetPlatformDefaultBackend` method that retrieves the default `GraphicsBackend` for the executing platform, chosen by order of availability if a backend is not supported or included in the build.
 
 ### Changed
 
 - [OpenGL] Binding a currently-mapped buffer as a vertex or index buffer now throws instead of producing undefined behavior.
 - [Core] Using a `Framebuffer` or `ResourceSet` that references a disposed resource now throws instead of producing undefined behavior.
+- [StartupUtilities] Deprecated `NeoVeldridStartup.GetPlatformDefaultBackend` in favor of `GraphicsDevice.GetPlatformDefaultBackend`.
 
 ### Removed
 

--- a/samples/common/SampleBase/BackendHelper.cs
+++ b/samples/common/SampleBase/BackendHelper.cs
@@ -25,7 +25,7 @@ namespace SampleBase
                         $"Unknown NEOVELDRID_BACKEND value: '{envBackend}'. Use: d3d11, vulkan, opengl, opengles")
                 };
             }
-            return NeoVeldridStartup.GetPlatformDefaultBackend();
+            return GraphicsDevice.GetAvailableBackend();
         }
     }
 }

--- a/samples/common/SampleBase/BackendHelper.cs
+++ b/samples/common/SampleBase/BackendHelper.cs
@@ -25,7 +25,7 @@ namespace SampleBase
                         $"Unknown NEOVELDRID_BACKEND value: '{envBackend}'. Use: d3d11, vulkan, opengl, opengles")
                 };
             }
-            return GraphicsDevice.GetAvailableBackend();
+            return GraphicsDevice.GetPlatformDefaultBackend();
         }
     }
 }

--- a/samples/demos/NeoDemo/NeoDemo.cs
+++ b/samples/demos/NeoDemo/NeoDemo.cs
@@ -62,7 +62,7 @@ namespace NeoVeldrid.NeoDemo
 #endif
             string backendEnv = Environment.GetEnvironmentVariable("NEOVELDRID_BACKEND");
             GraphicsBackend backend = string.IsNullOrEmpty(backendEnv)
-                ? GraphicsDevice.GetAvailableBackend()
+                ? GraphicsDevice.GetPlatformDefaultBackend()
                 : backendEnv.ToLowerInvariant() switch
                 {
                     "d3d11" or "direct3d11" => GraphicsBackend.Direct3D11,

--- a/samples/demos/NeoDemo/NeoDemo.cs
+++ b/samples/demos/NeoDemo/NeoDemo.cs
@@ -62,7 +62,7 @@ namespace NeoVeldrid.NeoDemo
 #endif
             string backendEnv = Environment.GetEnvironmentVariable("NEOVELDRID_BACKEND");
             GraphicsBackend backend = string.IsNullOrEmpty(backendEnv)
-                ? NeoVeldridStartup.GetPlatformDefaultBackend()
+                ? GraphicsDevice.GetAvailableBackend()
                 : backendEnv.ToLowerInvariant() switch
                 {
                     "d3d11" or "direct3d11" => GraphicsBackend.Direct3D11,

--- a/samples/integrations/FontStashText/Program.cs
+++ b/samples/integrations/FontStashText/Program.cs
@@ -24,7 +24,7 @@ internal class Program
 
         string backendEnv = Environment.GetEnvironmentVariable("NEOVELDRID_BACKEND");
         GraphicsBackend backend = string.IsNullOrEmpty(backendEnv)
-            ? NeoVeldridStartup.GetPlatformDefaultBackend()
+            ? GraphicsDevice.GetAvailableBackend()
             : backendEnv.ToLowerInvariant() switch
             {
                 "d3d11" or "direct3d11" => GraphicsBackend.Direct3D11,

--- a/samples/integrations/FontStashText/Program.cs
+++ b/samples/integrations/FontStashText/Program.cs
@@ -24,7 +24,7 @@ internal class Program
 
         string backendEnv = Environment.GetEnvironmentVariable("NEOVELDRID_BACKEND");
         GraphicsBackend backend = string.IsNullOrEmpty(backendEnv)
-            ? GraphicsDevice.GetAvailableBackend()
+            ? GraphicsDevice.GetPlatformDefaultBackend()
             : backendEnv.ToLowerInvariant() switch
             {
                 "d3d11" or "direct3d11" => GraphicsBackend.Direct3D11,

--- a/samples/techniques/GettingStarted/Program.cs
+++ b/samples/techniques/GettingStarted/Program.cs
@@ -60,7 +60,7 @@ void main()
 
             string backendEnv = Environment.GetEnvironmentVariable("NEOVELDRID_BACKEND");
             GraphicsBackend backend = string.IsNullOrEmpty(backendEnv)
-                ? NeoVeldridStartup.GetPlatformDefaultBackend()
+                ? GraphicsDevice.GetAvailableBackend()
                 : backendEnv.ToLowerInvariant() switch
                 {
                     "d3d11" or "direct3d11" => GraphicsBackend.Direct3D11,

--- a/samples/techniques/GettingStarted/Program.cs
+++ b/samples/techniques/GettingStarted/Program.cs
@@ -60,7 +60,7 @@ void main()
 
             string backendEnv = Environment.GetEnvironmentVariable("NEOVELDRID_BACKEND");
             GraphicsBackend backend = string.IsNullOrEmpty(backendEnv)
-                ? GraphicsDevice.GetAvailableBackend()
+                ? GraphicsDevice.GetPlatformDefaultBackend()
                 : backendEnv.ToLowerInvariant() switch
                 {
                     "d3d11" or "direct3d11" => GraphicsBackend.Direct3D11,

--- a/src/NeoVeldrid.StartupUtilities/NeoVeldridStartup.cs
+++ b/src/NeoVeldrid.StartupUtilities/NeoVeldridStartup.cs
@@ -17,7 +17,7 @@ namespace NeoVeldrid.StartupUtilities
             => CreateWindowAndGraphicsDevice(
                 windowCI,
                 new GraphicsDeviceOptions(),
-                GetPlatformDefaultBackend(),
+                GraphicsDevice.GetAvailableBackend(),
                 out window,
                 out gd);
 
@@ -26,7 +26,7 @@ namespace NeoVeldrid.StartupUtilities
             GraphicsDeviceOptions deviceOptions,
             out Sdl2Window window,
             out GraphicsDevice gd)
-            => CreateWindowAndGraphicsDevice(windowCI, deviceOptions, GetPlatformDefaultBackend(), out window, out gd);
+            => CreateWindowAndGraphicsDevice(windowCI, deviceOptions, GraphicsDevice.GetAvailableBackend(), out window, out gd);
 
         public static void CreateWindowAndGraphicsDevice(
             WindowCreateInfo windowCI,
@@ -93,9 +93,9 @@ namespace NeoVeldrid.StartupUtilities
         }
 
         public static GraphicsDevice CreateGraphicsDevice(Sdl2Window window)
-            => CreateGraphicsDevice(window, new GraphicsDeviceOptions(), GetPlatformDefaultBackend());
+            => CreateGraphicsDevice(window, new GraphicsDeviceOptions(), GraphicsDevice.GetAvailableBackend());
         public static GraphicsDevice CreateGraphicsDevice(Sdl2Window window, GraphicsDeviceOptions options)
-            => CreateGraphicsDevice(window, options, GetPlatformDefaultBackend());
+            => CreateGraphicsDevice(window, options, GraphicsDevice.GetAvailableBackend());
         public static GraphicsDevice CreateGraphicsDevice(Sdl2Window window, GraphicsBackend preferredBackend)
             => CreateGraphicsDevice(window, new GraphicsDeviceOptions(), preferredBackend);
         public static GraphicsDevice CreateGraphicsDevice(
@@ -160,6 +160,7 @@ namespace NeoVeldrid.StartupUtilities
             }
         }
 
+        [Obsolete("Use GraphicsDevice.GetAvailableBackend() instead.")]
         public static GraphicsBackend GetPlatformDefaultBackend()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/NeoVeldrid.StartupUtilities/NeoVeldridStartup.cs
+++ b/src/NeoVeldrid.StartupUtilities/NeoVeldridStartup.cs
@@ -17,7 +17,7 @@ namespace NeoVeldrid.StartupUtilities
             => CreateWindowAndGraphicsDevice(
                 windowCI,
                 new GraphicsDeviceOptions(),
-                GraphicsDevice.GetAvailableBackend(),
+                GraphicsDevice.GetPlatformDefaultBackend(),
                 out window,
                 out gd);
 
@@ -26,7 +26,7 @@ namespace NeoVeldrid.StartupUtilities
             GraphicsDeviceOptions deviceOptions,
             out Sdl2Window window,
             out GraphicsDevice gd)
-            => CreateWindowAndGraphicsDevice(windowCI, deviceOptions, GraphicsDevice.GetAvailableBackend(), out window, out gd);
+            => CreateWindowAndGraphicsDevice(windowCI, deviceOptions, GraphicsDevice.GetPlatformDefaultBackend(), out window, out gd);
 
         public static void CreateWindowAndGraphicsDevice(
             WindowCreateInfo windowCI,
@@ -93,9 +93,9 @@ namespace NeoVeldrid.StartupUtilities
         }
 
         public static GraphicsDevice CreateGraphicsDevice(Sdl2Window window)
-            => CreateGraphicsDevice(window, new GraphicsDeviceOptions(), GraphicsDevice.GetAvailableBackend());
+            => CreateGraphicsDevice(window, new GraphicsDeviceOptions(), GraphicsDevice.GetPlatformDefaultBackend());
         public static GraphicsDevice CreateGraphicsDevice(Sdl2Window window, GraphicsDeviceOptions options)
-            => CreateGraphicsDevice(window, options, GraphicsDevice.GetAvailableBackend());
+            => CreateGraphicsDevice(window, options, GraphicsDevice.GetPlatformDefaultBackend());
         public static GraphicsDevice CreateGraphicsDevice(Sdl2Window window, GraphicsBackend preferredBackend)
             => CreateGraphicsDevice(window, new GraphicsDeviceOptions(), preferredBackend);
         public static GraphicsDevice CreateGraphicsDevice(

--- a/src/NeoVeldrid.StartupUtilities/NeoVeldridStartup.cs
+++ b/src/NeoVeldrid.StartupUtilities/NeoVeldridStartup.cs
@@ -160,44 +160,8 @@ namespace NeoVeldrid.StartupUtilities
             }
         }
 
-        [Obsolete("Use GraphicsDevice.GetAvailableBackend() instead.")]
-        public static GraphicsBackend GetPlatformDefaultBackend()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-#if !EXCLUDE_D3D11_BACKEND
-                return GraphicsBackend.Direct3D11;
-#elif !EXCLUDE_VULKAN_BACKEND
-                return GraphicsBackend.Vulkan;
-#elif !EXCLUDE_OPENGL_BACKEND
-                return GraphicsBackend.OpenGL;
-#else
-                throw new NeoVeldridException("No graphics backend is available. Enable at least one backend.");
-#endif
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-#if !EXCLUDE_VULKAN_BACKEND
-                return GraphicsBackend.Vulkan; // Via MoltenVK
-#elif !EXCLUDE_OPENGL_BACKEND
-                return GraphicsBackend.OpenGL;
-#else
-                throw new NeoVeldridException("No graphics backend is available. Enable at least one backend.");
-#endif
-            }
-            else
-            {
-#if !EXCLUDE_VULKAN_BACKEND
-                return GraphicsDevice.IsBackendSupported(GraphicsBackend.Vulkan)
-                    ? GraphicsBackend.Vulkan
-                    : GraphicsBackend.OpenGL;
-#elif !EXCLUDE_OPENGL_BACKEND
-                return GraphicsBackend.OpenGL;
-#else
-                throw new NeoVeldridException("No graphics backend is available. Enable at least one backend.");
-#endif
-            }
-        }
+        [Obsolete("Use GraphicsDevice.GetAvailableBackend() directly instead.")]
+        public static GraphicsBackend GetPlatformDefaultBackend() => GraphicsDevice.GetPlatformDefaultBackend();
 
 #if !EXCLUDE_VULKAN_BACKEND
         public static GraphicsDevice CreateVulkanGraphicsDevice(GraphicsDeviceOptions options, Sdl2Window window)

--- a/src/NeoVeldrid/GraphicsDevice.cs
+++ b/src/NeoVeldrid/GraphicsDevice.cs
@@ -998,6 +998,30 @@ namespace NeoVeldrid
             }
         }
 
+        /// <summary>
+        /// Retrieves an available <see cref="GraphicsBackend"/> that is supported by the executing platform,
+        /// chosen by order of platform preference.
+        /// </summary>
+        /// <returns>An available <see cref="GraphicsBackend"/> that is supported by the executing platform.</returns>
+        public static GraphicsBackend GetAvailableBackend()
+        {
+#if !EXCLUDE_D3D11_BACKEND
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return GraphicsBackend.Direct3D11;
+#endif
+
+#if !EXCLUDE_VULKAN_BACKEND
+            if (Vk.VkGraphicsDevice.IsSupported())
+                return GraphicsBackend.Vulkan; // Common denominator backend.
+#endif
+
+#if !EXCLUDE_OPENGL_BACKEND                        
+            return GraphicsBackend.OpenGL;
+#endif
+
+            throw new NeoVeldridException("No graphics backend is available. Enable at least one backend.");
+        }
+
 #if !EXCLUDE_D3D11_BACKEND
         /// <summary>
         /// Creates a new <see cref="GraphicsDevice"/> using Direct3D 11.

--- a/src/NeoVeldrid/GraphicsDevice.cs
+++ b/src/NeoVeldrid/GraphicsDevice.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -999,11 +999,11 @@ namespace NeoVeldrid
         }
 
         /// <summary>
-        /// Retrieves an available <see cref="GraphicsBackend"/> that is supported by the executing platform,
-        /// chosen by order of platform preference.
+        /// Retrieves the default <see cref="GraphicsBackend"/> for the executing platform, chosen by order of
+        /// availability if a backend is not supported or included in the build.
         /// </summary>
-        /// <returns>An available <see cref="GraphicsBackend"/> that is supported by the executing platform.</returns>
-        public static GraphicsBackend GetAvailableBackend()
+        /// <returns>The default <see cref="GraphicsBackend"/> for the executing platform.</returns>
+        public static GraphicsBackend GetPlatformDefaultBackend()
         {
 #if !EXCLUDE_D3D11_BACKEND
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -1016,7 +1016,8 @@ namespace NeoVeldrid
 #endif
 
 #if !EXCLUDE_OPENGL_BACKEND                        
-            return GraphicsBackend.OpenGL;
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return GraphicsBackend.OpenGL;
 #endif
 
             throw new NeoVeldridException("No graphics backend is available. Enable at least one backend.");


### PR DESCRIPTION
## Summary
This pull request is a revision of #65 but focuses only on adding a method to `GraphicsDevice` that finds the ideal backend for the executing platform.

- Adds `GetAvailableBackend()` to `GraphicsDevice`.
- Makes `GetPlatformDefaultBackend()` in `NeoVeldridStartup` obsolete.
- Adjusts every use of `GetPlatformDefaultBackend()` to instead use `GetAvailableBackend()`.

## Backend Preference Order
On Windows, `Direct3D11` is chosen unless it has been excluded from the build. If `Direct3D11` isn't available, `Vulkan` is chosen if supported and not excluded from the build. If `Vulkan` isn't available, `OpenGL` is chosen if not excluded from the build. If `OpenGL` isn't available, an exception is thrown. 