### PR TITLE
[Samples] GLFW Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 ### Internal
 
 - Migrated the test projects to xUnit v3.
+- [Samples] Added a GLFW windowing sample under `samples/integrations`.
 
 ## [1.2.0] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 - [SDL2] Window creation failures now report the actual SDL error instead of always saying "Invalid window".
 - [SDL2] A failed window creation no longer hangs the `Sdl2Window` constructor when `threadedProcessing` is enabled.
 - [Vulkan] Fixed stale reads when draws, dispatches, or buffer copies consume compute shader output in the same command list.
+- [Vulkan] Fixed flashing and repeated swapchain recreation when presenting to high-DPI GLFW windows on macOS.
 
 ### Internal
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,6 +32,7 @@
         <PackageVersion Include="Silk.NET.Shaderc" Version="$(SilkNetVersion)" />
 
         <PackageVersion Include="Silk.NET.SDL" Version="$(SilkNetVersion)" />
+        <PackageVersion Include="Silk.NET.GLFW" Version="$(SilkNetVersion)" />
 
         <PackageVersion Include="Silk.NET.Assimp" Version="$(SilkNetVersion)" />
     </ItemGroup>

--- a/NeoVeldrid.Samples.slnf
+++ b/NeoVeldrid.Samples.slnf
@@ -7,6 +7,7 @@
       "samples\\common\\AssetProcessor\\AssetProcessor.csproj",
 	  "samples\\demos\\NeoDemo\\NeoDemo.csproj",
 	  "samples\\integrations\\FontStashText\\FontStashText.csproj",
+	  "samples\\integrations\\GlfwWindow\\GlfwWindow.csproj",
 	  "samples\\techniques\\AnimatedMesh\\AnimatedMesh.csproj",
       "samples\\techniques\\ComputeParticles\\ComputeParticles.csproj",
       "samples\\techniques\\ComputeTexture\\ComputeTexture.csproj",

--- a/NeoVeldrid.slnx
+++ b/NeoVeldrid.slnx
@@ -9,6 +9,7 @@
     </Folder>
     <Folder Name="/samples/integrations/">
         <Project Path="samples/integrations/FontStashText/FontStashText.csproj" />
+        <Project Path="samples/integrations/GlfwWindow/GlfwWindow.csproj" />
     </Folder>
     <Folder Name="/samples/techniques/">
         <Project Path="samples/techniques/AnimatedMesh/AnimatedMesh.csproj" />
@@ -25,13 +26,13 @@
         <Project Path="src/NeoVeldrid.ImGui/NeoVeldrid.ImGui.csproj" />
         <Project Path="src/NeoVeldrid.RenderDoc/NeoVeldrid.RenderDoc.csproj" />
         <Project Path="src/NeoVeldrid.SDL2/NeoVeldrid.SDL2.csproj" />
+        <Project Path="src/NeoVeldrid.SPIRV/NeoVeldrid.SPIRV.csproj" />
         <Project Path="src/NeoVeldrid.StartupUtilities/NeoVeldrid.StartupUtilities.csproj" />
         <Project Path="src/NeoVeldrid.Utilities/NeoVeldrid.Utilities.csproj" />
         <Project Path="src/NeoVeldrid/NeoVeldrid.csproj" />
-        <Project Path="src/NeoVeldrid.SPIRV/NeoVeldrid.SPIRV.csproj" />
     </Folder>
     <Folder Name="/tests/">
-        <Project Path="tests/NeoVeldrid.Tests/NeoVeldrid.Tests.csproj" />
         <Project Path="tests/NeoVeldrid.SPIRV.Tests/NeoVeldrid.SPIRV.Tests.csproj" />
+        <Project Path="tests/NeoVeldrid.Tests/NeoVeldrid.Tests.csproj" />
     </Folder>
 </Solution>

--- a/NeoVeldrid.slnx
+++ b/NeoVeldrid.slnx
@@ -26,13 +26,13 @@
         <Project Path="src/NeoVeldrid.ImGui/NeoVeldrid.ImGui.csproj" />
         <Project Path="src/NeoVeldrid.RenderDoc/NeoVeldrid.RenderDoc.csproj" />
         <Project Path="src/NeoVeldrid.SDL2/NeoVeldrid.SDL2.csproj" />
-        <Project Path="src/NeoVeldrid.SPIRV/NeoVeldrid.SPIRV.csproj" />
         <Project Path="src/NeoVeldrid.StartupUtilities/NeoVeldrid.StartupUtilities.csproj" />
         <Project Path="src/NeoVeldrid.Utilities/NeoVeldrid.Utilities.csproj" />
         <Project Path="src/NeoVeldrid/NeoVeldrid.csproj" />
+        <Project Path="src/NeoVeldrid.SPIRV/NeoVeldrid.SPIRV.csproj" />
     </Folder>
     <Folder Name="/tests/">
-        <Project Path="tests/NeoVeldrid.SPIRV.Tests/NeoVeldrid.SPIRV.Tests.csproj" />
         <Project Path="tests/NeoVeldrid.Tests/NeoVeldrid.Tests.csproj" />
+        <Project Path="tests/NeoVeldrid.SPIRV.Tests/NeoVeldrid.SPIRV.Tests.csproj" />
     </Folder>
 </Solution>

--- a/samples/README.md
+++ b/samples/README.md
@@ -26,6 +26,7 @@ Samples demonstrating how to integrate popular third-party libraries with NeoVel
 | Sample | Description | Run command |
 |--------|-------------|-------------|
 | **FontStashText** | Render fonts and text with [FontStashSharp](https://github.com/FontStashSharp/FontStashSharp). | `dotnet run --project samples/integrations/FontStashText/FontStashText.csproj` |
+| **GlfwWindow** | An implementation of `GettingStarted` using [GLFW](https://www.glfw.org/). | `dotnet run --project samples/integrations/GlfwWindow/GlfwWindow.csproj` |
 
 ## Full Demos
 

--- a/samples/integrations/GlfwWindow/GlfwWindow.csproj
+++ b/samples/integrations/GlfwWindow/GlfwWindow.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <ProjectReference Include="$(RootDir)\src\NeoVeldrid\NeoVeldrid.csproj" />
+        <ProjectReference Include="$(RootDir)\src\NeoVeldrid.SPIRV\NeoVeldrid.SPIRV.csproj" />
         <PackageReference Include="Silk.NET.GLFW" />
     </ItemGroup>
 

--- a/samples/integrations/GlfwWindow/GlfwWindow.csproj
+++ b/samples/integrations/GlfwWindow/GlfwWindow.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="$(RootDir)\src\NeoVeldrid\NeoVeldrid.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/samples/integrations/GlfwWindow/GlfwWindow.csproj
+++ b/samples/integrations/GlfwWindow/GlfwWindow.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <ProjectReference Include="$(RootDir)\src\NeoVeldrid\NeoVeldrid.csproj" />
+        <PackageReference Include="Silk.NET.GLFW" />
     </ItemGroup>
 
 </Project>

--- a/samples/integrations/GlfwWindow/Program.cs
+++ b/samples/integrations/GlfwWindow/Program.cs
@@ -1,11 +1,333 @@
+using NeoVeldrid;
+using NeoVeldrid.OpenGL;
+using NeoVeldrid.SPIRV;
+using Silk.NET.GLFW;
 using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace GlfwWindow;
 
-internal class Program
+internal unsafe class Program
 {
+    private static Glfw _glfw;
+    private static WindowHandle* _hwnd;
+    private static GraphicsDevice _graphicsDevice;
+
+    private static CommandList _commandList;
+    private static DeviceBuffer _vertexBuffer;
+    private static DeviceBuffer _indexBuffer;
+    private static Shader[] _shaders;
+    private static Pipeline _pipeline;
+
+    private const string VertexCode = @"
+#version 450
+
+layout(location = 0) in vec2 Position;
+layout(location = 1) in vec4 Color;
+
+layout(location = 0) out vec4 fsin_Color;
+
+void main()
+{
+    gl_Position = vec4(Position, 0, 1);
+    fsin_Color = Color;
+}";
+
+    private const string FragmentCode = @"
+#version 450
+
+layout(location = 0) in vec4 fsin_Color;
+layout(location = 0) out vec4 fsout_Color;
+
+void main()
+{
+    fsout_Color = fsin_Color;
+}";
+
     static void Main(string[] args)
     {
-        Console.WriteLine("Hello, World!");
+        string backendEnv = Environment.GetEnvironmentVariable("NEOVELDRID_BACKEND");
+        GraphicsBackend backend = string.IsNullOrEmpty(backendEnv)
+            ? GraphicsDevice.GetPlatformDefaultBackend()
+            : backendEnv.ToLowerInvariant() switch
+            {
+                "d3d11" or "direct3d11" => GraphicsBackend.Direct3D11,
+                "vulkan" or "vk" => GraphicsBackend.Vulkan,
+                "opengl" or "gl" => GraphicsBackend.OpenGL,
+                "opengles" or "gles" => GraphicsBackend.OpenGLES,
+                _ => throw new InvalidOperationException($"Unknown NEOVELDRID_BACKEND: '{backendEnv}'")
+            };
+
+        // Populate bindings and initialize GLFW.
+        _glfw = Glfw.GetApi();
+        if (!_glfw.Init())
+            throw new Exception("Failed to initialize GLFW.");
+
+        // GLFW handles the OpenGL context itself, but if we use another backend we need
+        // to tell GLFW not to create the OpenGL context.
+        if (backend == GraphicsBackend.OpenGL || backend == GraphicsBackend.OpenGLES)
+        {
+            GraphicsApiVersion version = GraphicsDevice.GetBackendVersion(backend);
+
+            _glfw.WindowHint(WindowHintClientApi.ClientApi,
+                backend == GraphicsBackend.OpenGL
+                ? ClientApi.OpenGL
+                : ClientApi.OpenGLES);
+
+            _glfw.WindowHint(WindowHintInt.ContextVersionMajor, version.Major); // Max GL version.
+            _glfw.WindowHint(WindowHintInt.ContextVersionMinor, version.Minor); // Max GL version.
+
+            // Disables the default 24-bit depth buffer.
+            _glfw.WindowHint(WindowHintInt.DepthBits, 0);
+
+            // Only desktop OpenGL needs a core profile.
+            if (backend == GraphicsBackend.OpenGL)
+                _glfw.WindowHint(WindowHintOpenGlProfile.OpenGlProfile, OpenGlProfile.Core);
+        }
+        else _glfw.WindowHint(WindowHintClientApi.ClientApi, ClientApi.NoApi);
+
+        int width = 960;
+        int height = 540;
+        _hwnd = _glfw.CreateWindow(width, height, $"GLFW + NeoVeldrid ({backend})", null, null);
+        if (_hwnd == null)
+        {
+            _glfw.Terminate(); // We can't continue from this point on, so we need to dispose of GLFW.
+            throw new Exception("Failed to create GLFW window.");
+        }
+
+        // Create the GraphicsDevice for the specified backend and attach it to the GLFW window.
+        var options = new GraphicsDeviceOptions
+        {
+            PreferStandardClipSpaceYDirection = true,
+            PreferDepthRangeZeroToOne = true
+        };
+        CreateGraphicsDevice(backend, options, width, height);
+
+        // Create the resources needed for drawing.
+        CreateResources();
+
+        while (!_glfw.WindowShouldClose(_hwnd))
+        {
+            // Without polling for events, titlebars and input won't be checked.
+            _glfw.PollEvents();
+
+            // We need to sync the GLFW window size and NeoVeldrid's framebuffer, or window resizing
+            // will not work.
+            _glfw.GetFramebufferSize(_hwnd, out int fbWidth, out int fbHeight);
+
+            if (fbWidth > 0 && fbHeight > 0 &&
+                (fbWidth != _graphicsDevice.SwapchainFramebuffer.Width
+                || fbHeight != _graphicsDevice.SwapchainFramebuffer.Height))
+            {
+                _graphicsDevice.ResizeMainWindow((uint)fbWidth, (uint)fbHeight);
+            }
+
+            // Drawing should be skipped if the window is minimized.
+            if (fbWidth == 0 || fbHeight == 0) continue;
+
+            Draw();
+        }
+
+        // Dispose of all resources needed for drawing.
+        DisposeResources();
+
+        _glfw.DestroyWindow(_hwnd);
+        _glfw.Terminate();
+    }
+
+    private static void CreateResources()
+    {
+        ResourceFactory factory = _graphicsDevice.ResourceFactory;
+
+        VertexPositionColor[] quadVertices =
+        {
+            new VertexPositionColor(new Vector2(-.75f, .75f), RgbaFloat.Red),
+            new VertexPositionColor(new Vector2(.75f, .75f), RgbaFloat.Green),
+            new VertexPositionColor(new Vector2(-.75f, -.75f), RgbaFloat.Blue),
+            new VertexPositionColor(new Vector2(.75f, -.75f), RgbaFloat.Yellow)
+        };
+        BufferDescription vbDescription = new BufferDescription(
+            4 * VertexPositionColor.SizeInBytes,
+            BufferUsage.VertexBuffer);
+        _vertexBuffer = factory.CreateBuffer(vbDescription);
+        _graphicsDevice.UpdateBuffer(_vertexBuffer, 0, quadVertices);
+
+        ushort[] quadIndices = { 0, 1, 2, 3 };
+        BufferDescription ibDescription = new BufferDescription(
+            4 * sizeof(ushort),
+            BufferUsage.IndexBuffer);
+        _indexBuffer = factory.CreateBuffer(ibDescription);
+        _graphicsDevice.UpdateBuffer(_indexBuffer, 0, quadIndices);
+
+        VertexLayoutDescription vertexLayout = new VertexLayoutDescription(
+            new VertexElementDescription("Position", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float2),
+            new VertexElementDescription("Color", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float4));
+
+        ShaderDescription vertexShaderDesc = new ShaderDescription(
+            ShaderStages.Vertex,
+            Encoding.UTF8.GetBytes(VertexCode),
+            "main");
+        ShaderDescription fragmentShaderDesc = new ShaderDescription(
+            ShaderStages.Fragment,
+            Encoding.UTF8.GetBytes(FragmentCode),
+            "main");
+
+        _shaders = factory.CreateFromSpirv(vertexShaderDesc, fragmentShaderDesc);
+
+        // Create pipeline
+        GraphicsPipelineDescription pipelineDescription = new GraphicsPipelineDescription();
+        pipelineDescription.BlendState = BlendStateDescription.SingleOverrideBlend;
+        pipelineDescription.DepthStencilState = new DepthStencilStateDescription(
+            depthTestEnabled: true,
+            depthWriteEnabled: true,
+            comparisonKind: ComparisonKind.LessEqual);
+        pipelineDescription.RasterizerState = new RasterizerStateDescription(
+            cullMode: FaceCullMode.Back,
+            fillMode: PolygonFillMode.Solid,
+            frontFace: FrontFace.Clockwise,
+            depthClipEnabled: true,
+            scissorTestEnabled: false);
+        pipelineDescription.PrimitiveTopology = PrimitiveTopology.TriangleStrip;
+        pipelineDescription.ResourceLayouts = System.Array.Empty<ResourceLayout>();
+        pipelineDescription.ShaderSet = new ShaderSetDescription(
+            vertexLayouts: new VertexLayoutDescription[] { vertexLayout },
+            shaders: _shaders);
+        pipelineDescription.Outputs = _graphicsDevice.SwapchainFramebuffer.OutputDescription;
+
+        _pipeline = factory.CreateGraphicsPipeline(pipelineDescription);
+
+        _commandList = factory.CreateCommandList();
+    }
+
+    private static void Draw()
+    {
+        // Begin() must be called before commands can be issued.
+        _commandList.Begin();
+
+        // We want to render directly to the output window.
+        _commandList.SetFramebuffer(_graphicsDevice.SwapchainFramebuffer);
+        _commandList.ClearColorTarget(0, RgbaFloat.Black);
+
+        // Set all relevant state to draw our quad.
+        _commandList.SetVertexBuffer(0, _vertexBuffer);
+        _commandList.SetIndexBuffer(_indexBuffer, IndexFormat.UInt16);
+        _commandList.SetPipeline(_pipeline);
+        // Issue a Draw command for a single instance with 4 indices.
+        _commandList.DrawIndexed(
+            indexCount: 4,
+            instanceCount: 1,
+            indexStart: 0,
+            vertexOffset: 0,
+            instanceStart: 0);
+
+        // End() must be called before commands can be submitted for execution.
+        _commandList.End();
+        _graphicsDevice.SubmitCommands(_commandList);
+
+        // Once commands have been submitted, the rendered image can be presented to the application window.
+        _graphicsDevice.SwapBuffers();
+    }
+
+    public static void DisposeResources()
+    {
+        _pipeline.Dispose();
+        foreach (Shader shader in _shaders)
+        {
+            shader.Dispose();
+        }
+        _commandList.Dispose();
+        _vertexBuffer.Dispose();
+        _indexBuffer.Dispose();
+        _graphicsDevice.Dispose();
+    }
+
+    public static void CreateGraphicsDevice(GraphicsBackend backend, GraphicsDeviceOptions options, int width, int height)
+    {
+        if (backend == GraphicsBackend.OpenGL || backend == GraphicsBackend.OpenGLES)
+        {
+            _glfw.MakeContextCurrent(_hwnd);
+
+            var platformInfo = new OpenGLPlatformInfo(
+                openGLContextHandle: (nint)_hwnd,
+                getProcAddress: name => (nint)_glfw.GetProcAddress(name),
+                makeCurrent: context => _glfw.MakeContextCurrent((WindowHandle*)context),
+                getCurrentContext: () => (nint)_glfw.GetCurrentContext(),
+                clearCurrentContext: () => _glfw.MakeContextCurrent(null),
+                deleteContext: _ => { }, // GLFW handles context cleanup when DestroyWindow is called.
+                swapBuffers: () => _glfw.SwapBuffers(_hwnd),
+                setSyncToVerticalBlank: sync => _glfw.SwapInterval(sync ? 1 : 0),
+                setSwapchainFramebuffer: () => { },
+                resizeSwapchain: (w, h) => { }
+            );
+
+            _graphicsDevice = GraphicsDevice.CreateOpenGL(options, platformInfo, (uint)width, (uint)height);
+        }
+        else
+        {
+            var nativeWindow = new GlfwNativeWindow(_glfw, _hwnd);
+            SwapchainSource source = null;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && nativeWindow.Win32.HasValue)
+            {
+                source = SwapchainSource.CreateWin32(
+                    nativeWindow.Win32.Value.Hwnd,
+                    nativeWindow.Win32.Value.HInstance
+                );
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                if (nativeWindow.Wayland.HasValue)
+                {
+                    source = SwapchainSource.CreateWayland(
+                        nativeWindow.Wayland.Value.Display,
+                        nativeWindow.Wayland.Value.Surface
+                    );
+                }
+                if (nativeWindow.X11.HasValue)
+                {
+                    source = SwapchainSource.CreateXlib(
+                        (nint)nativeWindow.X11.Value.Display,
+                        (nint)nativeWindow.X11.Value.Window
+                    );
+                }
+            }
+            else throw new PlatformNotSupportedException($"The {backend} backend does not support SwapchainSource creation.");
+
+            var swapchainDesc = new SwapchainDescription(
+                source,
+                (uint)width,
+                (uint)height,
+                options.SwapchainDepthFormat,
+                options.SyncToVerticalBlank,
+                options.SwapchainSrgbFormat
+            );
+
+            if (backend == GraphicsBackend.Direct3D11)
+            {
+                _graphicsDevice = GraphicsDevice.CreateD3D11(options, swapchainDesc);
+            }
+            else if (backend == GraphicsBackend.Vulkan)
+            {
+                _graphicsDevice = GraphicsDevice.CreateVulkan(options, swapchainDesc);
+            }
+            else
+            {
+                throw new PlatformNotSupportedException($"The {backend} backend is not supported.");
+            }
+        }
+    }
+}
+
+struct VertexPositionColor
+{
+    public const uint SizeInBytes = 24;
+    public Vector2 Position;
+    public RgbaFloat Color;
+    public VertexPositionColor(Vector2 position, RgbaFloat color)
+    {
+        Position = position;
+        Color = color;
     }
 }

--- a/samples/integrations/GlfwWindow/Program.cs
+++ b/samples/integrations/GlfwWindow/Program.cs
@@ -4,7 +4,6 @@ using NeoVeldrid.SPIRV;
 using Silk.NET.GLFW;
 using System;
 using System.Numerics;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace GlfwWindow;
@@ -63,7 +62,7 @@ void main()
         // Populate bindings and initialize GLFW.
         _glfw = Glfw.GetApi();
         if (!_glfw.Init())
-            throw new Exception("Failed to initialize GLFW.");
+            throw new InvalidOperationException("Failed to initialize GLFW.");
 
         // GLFW handles the OpenGL context itself, but if we use another backend we need
         // to tell GLFW not to create the OpenGL context.
@@ -76,8 +75,9 @@ void main()
                 ? ClientApi.OpenGL
                 : ClientApi.OpenGLES);
 
-            _glfw.WindowHint(WindowHintInt.ContextVersionMajor, version.Major); // Max GL version.
-            _glfw.WindowHint(WindowHintInt.ContextVersionMinor, version.Minor); // Max GL version.
+            // Ask for the newest version the driver reports.
+            _glfw.WindowHint(WindowHintInt.ContextVersionMajor, version.Major);
+            _glfw.WindowHint(WindowHintInt.ContextVersionMinor, version.Minor);
 
             // Disables the default 24-bit depth buffer.
             _glfw.WindowHint(WindowHintInt.DepthBits, 0);
@@ -86,7 +86,10 @@ void main()
             if (backend == GraphicsBackend.OpenGL)
                 _glfw.WindowHint(WindowHintOpenGlProfile.OpenGlProfile, OpenGlProfile.Core);
         }
-        else _glfw.WindowHint(WindowHintClientApi.ClientApi, ClientApi.NoApi);
+        else
+        {
+            _glfw.WindowHint(WindowHintClientApi.ClientApi, ClientApi.NoApi);
+        }
 
         int width = 960;
         int height = 540;
@@ -94,7 +97,7 @@ void main()
         if (_hwnd == null)
         {
             _glfw.Terminate(); // We can't continue from this point on, so we need to dispose of GLFW.
-            throw new Exception("Failed to create GLFW window.");
+            throw new InvalidOperationException("Failed to create GLFW window.");
         }
 
         // Create the GraphicsDevice for the specified backend and attach it to the GLFW window.
@@ -230,7 +233,7 @@ void main()
         _graphicsDevice.SwapBuffers();
     }
 
-    public static void DisposeResources()
+    private static void DisposeResources()
     {
         _pipeline.Dispose();
         foreach (Shader shader in _shaders)
@@ -243,12 +246,18 @@ void main()
         _graphicsDevice.Dispose();
     }
 
-    public static void CreateGraphicsDevice(GraphicsBackend backend, GraphicsDeviceOptions options, int width, int height)
+    private static void CreateGraphicsDevice(
+        GraphicsBackend backend,
+        GraphicsDeviceOptions options,
+        int width,
+        int height)
     {
         if (backend == GraphicsBackend.OpenGL || backend == GraphicsBackend.OpenGLES)
         {
             _glfw.MakeContextCurrent(_hwnd);
 
+            // The shorter overload is intentional: leaving setSwapchainFramebuffer unset is what makes
+            // NeoVeldrid bind the default framebuffer (FBO 0), which is the one GLFW presents from.
             var platformInfo = new OpenGLPlatformInfo(
                 openGLContextHandle: (nint)_hwnd,
                 getProcAddress: name => (nint)_glfw.GetProcAddress(name),
@@ -257,46 +266,15 @@ void main()
                 clearCurrentContext: () => _glfw.MakeContextCurrent(null),
                 deleteContext: _ => { }, // GLFW handles context cleanup when DestroyWindow is called.
                 swapBuffers: () => _glfw.SwapBuffers(_hwnd),
-                setSyncToVerticalBlank: sync => _glfw.SwapInterval(sync ? 1 : 0),
-                setSwapchainFramebuffer: () => { },
-                resizeSwapchain: (w, h) => { }
+                setSyncToVerticalBlank: sync => _glfw.SwapInterval(sync ? 1 : 0)
             );
 
             _graphicsDevice = GraphicsDevice.CreateOpenGL(options, platformInfo, (uint)width, (uint)height);
         }
         else
         {
-            var nativeWindow = new GlfwNativeWindow(_glfw, _hwnd);
-            SwapchainSource source = null;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && nativeWindow.Win32.HasValue)
-            {
-                source = SwapchainSource.CreateWin32(
-                    nativeWindow.Win32.Value.Hwnd,
-                    nativeWindow.Win32.Value.HInstance
-                );
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                if (nativeWindow.Wayland.HasValue)
-                {
-                    source = SwapchainSource.CreateWayland(
-                        nativeWindow.Wayland.Value.Display,
-                        nativeWindow.Wayland.Value.Surface
-                    );
-                }
-                if (nativeWindow.X11.HasValue)
-                {
-                    source = SwapchainSource.CreateXlib(
-                        (nint)nativeWindow.X11.Value.Display,
-                        (nint)nativeWindow.X11.Value.Window
-                    );
-                }
-            }
-            else throw new PlatformNotSupportedException($"The {backend} backend does not support SwapchainSource creation.");
-
             var swapchainDesc = new SwapchainDescription(
-                source,
+                CreateSwapchainSource(),
                 (uint)width,
                 (uint)height,
                 options.SwapchainDepthFormat,
@@ -317,6 +295,45 @@ void main()
                 throw new PlatformNotSupportedException($"The {backend} backend is not supported.");
             }
         }
+    }
+
+    private static SwapchainSource CreateSwapchainSource()
+    {
+        var nativeWindow = new GlfwNativeWindow(_glfw, _hwnd);
+
+        // GLFW only fills in the handles for the windowing system it is running on, so the first
+        // one with a value is the one to build the SwapchainSource from.
+        if (nativeWindow.Win32.HasValue)
+        {
+            return SwapchainSource.CreateWin32(
+                nativeWindow.Win32.Value.Hwnd,
+                nativeWindow.Win32.Value.HInstance
+            );
+        }
+
+        if (nativeWindow.Wayland.HasValue)
+        {
+            return SwapchainSource.CreateWayland(
+                nativeWindow.Wayland.Value.Display,
+                nativeWindow.Wayland.Value.Surface
+            );
+        }
+
+        if (nativeWindow.X11.HasValue)
+        {
+            return SwapchainSource.CreateXlib(
+                (nint)nativeWindow.X11.Value.Display,
+                (nint)nativeWindow.X11.Value.Window
+            );
+        }
+
+        if (nativeWindow.Cocoa.HasValue)
+        {
+            return SwapchainSource.CreateNSWindow(nativeWindow.Cocoa.Value);
+        }
+
+        throw new PlatformNotSupportedException(
+            "GLFW did not report a native window handle that NeoVeldrid can create a SwapchainSource from.");
     }
 }
 

--- a/samples/integrations/GlfwWindow/Program.cs
+++ b/samples/integrations/GlfwWindow/Program.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace GlfwWindow;
+
+internal class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Hello, World!");
+    }
+}

--- a/src/NeoVeldrid/Vk/VkSurfaceUtil.cs
+++ b/src/NeoVeldrid/Vk/VkSurfaceUtil.cs
@@ -187,22 +187,29 @@ internal static unsafe class VkSurfaceUtil
 
     private static IntPtr GetOrCreateMetalLayer(IntPtr nsView)
     {
-        // Ensure the view is layer-backed
-        ObjC.MsgSendBool(nsView, ObjC.Sel("setWantsLayer:"), 1);
-
         IntPtr layer = ObjC.MsgSend(nsView, ObjC.Sel("layer"));
         IntPtr caMetalLayerClass = ObjC.GetClass("CAMetalLayer");
 
-        if (layer != IntPtr.Zero && ObjC.MsgSendBool_Ret(layer, ObjC.Sel("isKindOfClass:"), caMetalLayerClass))
+        if (layer == IntPtr.Zero || !ObjC.MsgSendBool_Ret(layer, ObjC.Sel("isKindOfClass:"), caMetalLayerClass))
         {
-            return layer;
+            layer = ObjC.MsgSend(caMetalLayerClass, ObjC.Sel("alloc"));
+            layer = ObjC.MsgSend(layer, ObjC.Sel("init"));
+
+            if (ObjC.MsgSendBool_Ret(nsView, ObjC.Sel("wantsBestResolutionOpenGLSurface")))
+            {
+                IntPtr window = ObjC.MsgSend(nsView, ObjC.Sel("window"));
+                if (window != IntPtr.Zero)
+                {
+                    double contentsScale = ObjC.MsgSendDouble_Ret(window, ObjC.Sel("backingScaleFactor"));
+                    ObjC.MsgSendDouble(layer, ObjC.Sel("setContentsScale:"), contentsScale);
+                }
+            }
+
+            ObjC.MsgSendPtr(nsView, ObjC.Sel("setLayer:"), layer);
         }
 
-        // Create a new CAMetalLayer and set it on the view
-        IntPtr metalLayer = ObjC.MsgSend(caMetalLayerClass, ObjC.Sel("alloc"));
-        metalLayer = ObjC.MsgSend(metalLayer, ObjC.Sel("init"));
-        ObjC.MsgSendPtr(nsView, ObjC.Sel("setLayer:"), metalLayer);
-        return metalLayer;
+        ObjC.MsgSendBool(nsView, ObjC.Sel("setWantsLayer:"), 1);
+        return layer;
     }
 
     // Minimal ObjC runtime P/Invoke for macOS surface creation.
@@ -225,6 +232,16 @@ internal static unsafe class VkSurfaceUtil
 
         [DllImport(Lib, EntryPoint = "objc_msgSend")]
         public static extern void MsgSendBool(IntPtr receiver, IntPtr selector, byte arg);
+
+        [DllImport(Lib, EntryPoint = "objc_msgSend")]
+        public static extern void MsgSendDouble(IntPtr receiver, IntPtr selector, double arg);
+
+        [DllImport(Lib, EntryPoint = "objc_msgSend")]
+        public static extern double MsgSendDouble_Ret(IntPtr receiver, IntPtr selector);
+
+        [DllImport(Lib, EntryPoint = "objc_msgSend")]
+        [return: MarshalAs(UnmanagedType.U1)]
+        public static extern bool MsgSendBool_Ret(IntPtr receiver, IntPtr selector);
 
         [DllImport(Lib, EntryPoint = "objc_msgSend")]
         [return: MarshalAs(UnmanagedType.U1)]


### PR DESCRIPTION
## Summary
This pull request adds the `GlfwWindow` integration sample, which provides an implementation of the `GettingStarted` sample while using GLFW for windowing instead of NeoVeldrid's preferred SDL windowing.

It also corrects NeoVeldrid's Cocoa Vulkan surface setup so GLFW windows render reliably with MoltenVK on high-DPI macOS displays.

## Backend Support
- [x] DirectX11
- [x] Vulkan
- [x] OpenGL
- [x] OpenGLES
- [x] MoltenVK
