### PR TITLE
[StartupUtilities] Point the GetPlatformDefaultBackend deprecation at the right method

### DIFF
--- a/src/NeoVeldrid.StartupUtilities/NeoVeldridStartup.cs
+++ b/src/NeoVeldrid.StartupUtilities/NeoVeldridStartup.cs
@@ -160,7 +160,7 @@ public static unsafe class NeoVeldridStartup
         }
     }
 
-    [Obsolete("Use GraphicsDevice.GetAvailableBackend() directly instead.")]
+    [Obsolete("Use GraphicsDevice.GetPlatformDefaultBackend() directly instead.")]
     public static GraphicsBackend GetPlatformDefaultBackend() => GraphicsDevice.GetPlatformDefaultBackend();
 
 #if !EXCLUDE_VULKAN_BACKEND


### PR DESCRIPTION
The deprecation message told callers to use `GraphicsDevice.GetAvailableBackend()`, which doesn't exist. The replacement is `GraphicsDevice.GetPlatformDefaultBackend()`, which is what the method already forwards to.