### PR TITLE
[SDL2] Report the real SDL error when window creation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 ## [Unreleased]
 
+### Fixed
+
+- [SDL2] Window creation failures now report the actual SDL error instead of always saying "Invalid window".
+- [SDL2] A failed window creation no longer hangs the `Sdl2Window` constructor when `threadedProcessing` is enabled.
+
 ## [1.2.0] - 2026-07-03
 
 This release adds pre-initialization introspection (query a backend's API version and the platform default before a device exists), debug-state properties, and dedicated exceptions for mapped- and disposed-resource errors. It also ships a new FontStashSharp sample showing how to render text.

--- a/src/NeoVeldrid.SDL2/Sdl2Window.cs
+++ b/src/NeoVeldrid.SDL2/Sdl2Window.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -75,11 +76,14 @@ public unsafe class Sdl2Window
 
                 Task.Factory.StartNew(WindowOwnerRoutine, wp, TaskCreationOptions.LongRunning);
                 mre.WaitOne();
+                Rethrow(wp.CreationException);
             }
         }
         else
         {
+            _sdl.ClearError();
             _window = _sdl.CreateWindow(title, x, y, width, height, (uint)flags);
+            ThrowIfCreationFailed(_window);
             WindowID = _sdl.GetWindowID(_window);
             Sdl2WindowRegistry.RegisterWindow(this);
             PostWindowCreated(flags);
@@ -102,14 +106,40 @@ public unsafe class Sdl2Window
 
                 Task.Factory.StartNew(WindowOwnerRoutine, wp, TaskCreationOptions.LongRunning);
                 mre.WaitOne();
+                Rethrow(wp.CreationException);
             }
         }
         else
         {
+            _sdl.ClearError();
             _window = _sdl.CreateWindowFrom((void*)windowHandle);
+            ThrowIfCreationFailed(_window);
             WindowID = _sdl.GetWindowID(_window);
             Sdl2WindowRegistry.RegisterWindow(this);
             PostWindowCreated(0);
+        }
+    }
+
+    private static void ThrowIfCreationFailed(Silk.NET.SDL.Window* window)
+    {
+        if (window == null)
+        {
+            throw new InvalidOperationException("SDL window creation failed: " + GetSdlError());
+        }
+    }
+
+    private static string GetSdlError()
+    {
+        string error = _sdl.GetErrorS();
+        return string.IsNullOrEmpty(error) ? "unknown SDL error" : error;
+    }
+
+    // Preserves the original stack trace of an exception raised on the window's own thread.
+    private static void Rethrow(Exception creationException)
+    {
+        if (creationException != null)
+        {
+            ExceptionDispatchInfo.Capture(creationException).Throw();
         }
     }
 
@@ -344,11 +374,26 @@ public unsafe class Sdl2Window
     private void WindowOwnerRoutine(object state)
     {
         WindowParams wp = (WindowParams)state;
-        _window = wp.Create();
-        WindowID = _sdl.GetWindowID(_window);
-        Sdl2WindowRegistry.RegisterWindow(this);
-        PostWindowCreated(wp.WindowFlags);
-        wp.ResetEvent.Set();
+        try
+        {
+            _sdl.ClearError();
+            _window = wp.Create();
+            ThrowIfCreationFailed(_window);
+            WindowID = _sdl.GetWindowID(_window);
+            Sdl2WindowRegistry.RegisterWindow(this);
+            PostWindowCreated(wp.WindowFlags);
+        }
+        catch (Exception ex)
+        {
+            // Hand the failure back to the constructor, which is blocked on ResetEvent. Without
+            // this the event is never set and the caller waits forever.
+            wp.CreationException = ex;
+            return;
+        }
+        finally
+        {
+            wp.ResetEvent.Set();
+        }
 
         double previousPollTimeMs = 0;
         Stopwatch sw = new Stopwatch();
@@ -1024,6 +1069,8 @@ public unsafe class Sdl2Window
         public IntPtr WindowHandle { get; set; }
 
         public ManualResetEvent ResetEvent { get; set; }
+
+        public Exception CreationException { get; set; }
 
         public Silk.NET.SDL.Window* Create()
         {

--- a/src/NeoVeldrid.SDL2/Sdl2WindowRegistry.cs
+++ b/src/NeoVeldrid.SDL2/Sdl2WindowRegistry.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Silk.NET.SDL;
 
 namespace NeoVeldrid.Sdl2;
@@ -22,20 +20,10 @@ internal static class Sdl2WindowRegistry
 
     public static void RegisterWindow(Sdl2Window window)
     {
-        if (window.WindowID == 0)
-        {
-            throw new InvalidOperationException("SDL window creation failed: " + GetSdlError());
-        }
-
         lock (Lock)
         {
             _eventsByWindowID.Add(window.WindowID, window);
         }
-    }
-
-    private static unsafe string GetSdlError()
-    {
-        return Marshal.PtrToStringUTF8((nint)Sdl2Window.SdlInstance.GetError()) ?? "unknown SDL error";
     }
 
     public static void RemoveWindow(Sdl2Window window)


### PR DESCRIPTION
Every failed window creation reported `SDL window creation failed: Invalid window`, which says nothing. SDL keeps a single error string that the next call overwrites, and `GetWindowID(null)` ran before the error was ever read, replacing the real cause with its own.

On macOS the real message is `NSWindow should only be instantiated on the main thread!`, which tells you the cause and the fix in one line.

The returned handle is now checked immediately after creation, with `ClearError()` before it so a stale error from an unrelated call cannot be misreported as the cause. `Sdl2WindowRegistry.RegisterWindow` no longer formats an error it has no way to describe accurately.

## Threaded path deadlock

`WindowOwnerRoutine` signalled the waiting constructor only after registration succeeded. A failed creation threw first, so the event was never set and the constructor blocked on `ResetEvent` forever, turning an error into a silent hang. The creation sequence is now wrapped so the event is always set, and the exception is handed back to the constructor and rethrown with its original stack trace.

Nothing in the repo uses that path, since `NeoVeldridStartup` passes `threadedProcessing: false`, but the constructor is public API.

## Scope

This is diagnostics only. It does not make any currently failing test pass. The macOS GPU tests still fail whenever xUnit runs them off the main thread, they just say why now.