### PR TITLE
[Tests] Run SDL windows on the main thread so the GPU suite works on macOS

### DIFF
--- a/tests/NeoVeldrid.Tests/DisposalTests.RegressionTests.cs
+++ b/tests/NeoVeldrid.Tests/DisposalTests.RegressionTests.cs
@@ -34,7 +34,10 @@ public abstract class DeviceDisposalRegressionTests<T> where T : GraphicsDeviceC
             gd.Dispose();
             gd.Dispose();
             Assert.True(gd.IsDisposed);
-            window?.Close();
+            if (window != null)
+            {
+                MainThread.Invoke(window.Close);
+            }
         });
     }
 }

--- a/tests/NeoVeldrid.Tests/MainThread.cs
+++ b/tests/NeoVeldrid.Tests/MainThread.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+
+namespace NeoVeldrid.Tests;
+
+/// <summary>
+/// Runs work on the thread that calls <see cref="Pump"/>.
+/// </summary>
+/// <remarks>
+/// macOS requires SDL windows to be created and destroyed on the process main thread,
+/// and xUnit runs tests on pool threads.
+/// </remarks>
+public static class MainThread
+{
+    private static readonly BlockingCollection<Action> _work = new BlockingCollection<Action>();
+
+    private static Thread _pumpThread;
+
+    /// <summary>
+    /// Runs queued work on the calling thread until <paramref name="until"/> is cancelled.
+    /// </summary>
+    /// <param name="until">The token that stops the pump when cancelled.</param>
+    public static void Pump(CancellationToken until)
+    {
+        _pumpThread = Thread.CurrentThread;
+        try
+        {
+            foreach (Action work in _work.GetConsumingEnumerable(until))
+            {
+                work();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            _pumpThread = null;
+        }
+    }
+
+    /// <summary>
+    /// Runs <paramref name="func"/> on the pumping thread and returns its result. Exceptions are
+    /// rethrown on the calling thread with their original stack trace.
+    /// </summary>
+    /// <typeparam name="T">The result type.</typeparam>
+    /// <param name="func">The work to run.</param>
+    /// <returns>The result of <paramref name="func"/>.</returns>
+    public static T Invoke<T>(Func<T> func)
+    {
+        Thread pump = _pumpThread;
+        if (pump == null || pump == Thread.CurrentThread)
+        {
+            return func();
+        }
+
+        T result = default;
+        Exception error = null;
+
+        using (ManualResetEventSlim done = new ManualResetEventSlim(false))
+        {
+            _work.Add(() =>
+            {
+                try
+                {
+                    result = func();
+                }
+                catch (Exception ex)
+                {
+                    error = ex;
+                }
+                finally
+                {
+                    done.Set();
+                }
+            });
+
+            done.Wait();
+        }
+
+        if (error != null)
+        {
+            ExceptionDispatchInfo.Capture(error).Throw();
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Runs <paramref name="action"/> on the pumping thread.
+    /// </summary>
+    /// <param name="action">The work to run.</param>
+    public static void Invoke(Action action)
+    {
+        Invoke<object>(() =>
+        {
+            action();
+            return null;
+        });
+    }
+}

--- a/tests/NeoVeldrid.Tests/Program.cs
+++ b/tests/NeoVeldrid.Tests/Program.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using NeoVeldrid.Tests;
 
 class Program
 {
@@ -7,7 +9,26 @@ class Program
     {
         List<string> newArgs = new List<string>(args);
         newArgs.Insert(0, typeof(Program).Assembly.Location);
-        int returnCode = Xunit.ConsoleClient.Program.Main(newArgs.ToArray());
+
+        // xUnit runs tests on pool threads, but we want to start our window in the main thread.
+        int returnCode = 0;
+        using CancellationTokenSource cts = new CancellationTokenSource();
+        Thread runner = new Thread(() =>
+        {
+            try
+            {
+                returnCode = Xunit.ConsoleClient.Program.Main(newArgs.ToArray());
+            }
+            finally
+            {
+                cts.Cancel();
+            }
+        });
+
+        runner.Start();
+        MainThread.Pump(cts.Token);
+        runner.Join();
+
         Console.WriteLine("Tests finished. Press any key to exit.");
         if (!Console.IsInputRedirected)
         {

--- a/tests/NeoVeldrid.Tests/SwapchainTests.RegressionTests.cs
+++ b/tests/NeoVeldrid.Tests/SwapchainTests.RegressionTests.cs
@@ -70,7 +70,11 @@ public class SwapchainRegressionTests
         GraphicsDevice gd = null;
         try
         {
-            NeoVeldridStartup.CreateWindowAndGraphicsDevice(wci, options, backend, out window, out gd);
+            (window, gd) = MainThread.Invoke(() =>
+            {
+                NeoVeldridStartup.CreateWindowAndGraphicsDevice(wci, options, backend, out Sdl2Window w, out GraphicsDevice d);
+                return (w, d);
+            });
 
             PixelFormat colorFormat = gd.MainSwapchain.Framebuffer.ColorTargets[0].Target.Format;
 
@@ -79,7 +83,10 @@ public class SwapchainRegressionTests
         finally
         {
             gd?.Dispose();
-            window?.Close();
+            if (window != null)
+            {
+                MainThread.Invoke(window.Close);
+            }
         }
     }
 }

--- a/tests/NeoVeldrid.Tests/SwapchainTests.cs
+++ b/tests/NeoVeldrid.Tests/SwapchainTests.cs
@@ -22,7 +22,7 @@ public abstract class SwapchainTests<T> : GraphicsDeviceTestBase<T> where T : Gr
             WindowInitialState = WindowState.Hidden,
             WindowTitle = "SwapchainTestWindow",
         };
-        Sdl2Window window = NeoVeldridStartup.CreateWindow(ref wci);
+        Sdl2Window window = MainThread.Invoke(() => NeoVeldridStartup.CreateWindow(wci));
         SwapchainSource source = NeoVeldridStartup.GetSwapchainSource(window);
         SwapchainDescription swapchainDesc = new SwapchainDescription(source, 100, 100, depthFormat, syncToVerticalBlank);
         Swapchain swapchain = RF.CreateSwapchain(ref swapchainDesc);
@@ -39,7 +39,7 @@ public abstract class SwapchainTests<T> : GraphicsDeviceTestBase<T> where T : Gr
 
         Assert.Equal(syncToVerticalBlank, swapchain.SyncToVerticalBlank);
 
-        window.Close();
+        MainThread.Invoke(window.Close);
     }
 }
 

--- a/tests/NeoVeldrid.Tests/TestUtils.cs
+++ b/tests/NeoVeldrid.Tests/TestUtils.cs
@@ -14,16 +14,26 @@ public static class TestUtils
 
     public static void CreateVulkanDeviceWithSwapchain(out Sdl2Window window, out GraphicsDevice gd)
     {
-        WindowCreateInfo wci = new WindowCreateInfo
+        (window, gd) = CreateDeviceWithSwapchain(GraphicsBackend.Vulkan);
+    }
+
+    // macOS only allows SDL windows on the main thread, so every windowed device goes through here.
+    private static (Sdl2Window Window, GraphicsDevice Device) CreateDeviceWithSwapchain(GraphicsBackend backend)
+    {
+        return MainThread.Invoke(() =>
         {
-            WindowWidth = 200,
-            WindowHeight = 200,
-            WindowInitialState = WindowState.Hidden,
-        };
+            WindowCreateInfo wci = new WindowCreateInfo
+            {
+                WindowWidth = 200,
+                WindowHeight = 200,
+                WindowInitialState = WindowState.Hidden,
+            };
 
-        GraphicsDeviceOptions options = new GraphicsDeviceOptions(true, PixelFormat.R16_UNorm, false);
+            GraphicsDeviceOptions options = new GraphicsDeviceOptions(true, PixelFormat.R16_UNorm, false);
 
-        NeoVeldridStartup.CreateWindowAndGraphicsDevice(wci, options, GraphicsBackend.Vulkan, out window, out gd);
+            NeoVeldridStartup.CreateWindowAndGraphicsDevice(wci, options, backend, out Sdl2Window window, out GraphicsDevice gd);
+            return (window, gd);
+        });
     }
 
 #if TEST_D3D11
@@ -34,45 +44,18 @@ public static class TestUtils
 
     public static void CreateD3D11DeviceWithSwapchain(out Sdl2Window window, out GraphicsDevice gd)
     {
-        WindowCreateInfo wci = new WindowCreateInfo
-        {
-            WindowWidth = 200,
-            WindowHeight = 200,
-            WindowInitialState = WindowState.Hidden,
-        };
-
-        GraphicsDeviceOptions options = new GraphicsDeviceOptions(true, PixelFormat.R16_UNorm, false);
-
-        NeoVeldridStartup.CreateWindowAndGraphicsDevice(wci, options, GraphicsBackend.Direct3D11, out window, out gd);
+        (window, gd) = CreateDeviceWithSwapchain(GraphicsBackend.Direct3D11);
     }
 #endif
 
     internal static void CreateOpenGLDevice(out Sdl2Window window, out GraphicsDevice gd)
     {
-        WindowCreateInfo wci = new WindowCreateInfo
-        {
-            WindowWidth = 200,
-            WindowHeight = 200,
-            WindowInitialState = WindowState.Hidden,
-        };
-
-        GraphicsDeviceOptions options = new GraphicsDeviceOptions(true, PixelFormat.R16_UNorm, false);
-
-        NeoVeldridStartup.CreateWindowAndGraphicsDevice(wci, options, GraphicsBackend.OpenGL, out window, out gd);
+        (window, gd) = CreateDeviceWithSwapchain(GraphicsBackend.OpenGL);
     }
 
     internal static void CreateOpenGLESDevice(out Sdl2Window window, out GraphicsDevice gd)
     {
-        WindowCreateInfo wci = new WindowCreateInfo
-        {
-            WindowWidth = 200,
-            WindowHeight = 200,
-            WindowInitialState = WindowState.Hidden,
-        };
-
-        GraphicsDeviceOptions options = new GraphicsDeviceOptions(true, PixelFormat.R16_UNorm, false);
-
-        NeoVeldridStartup.CreateWindowAndGraphicsDevice(wci, options, GraphicsBackend.OpenGLES, out window, out gd);
+        (window, gd) = CreateDeviceWithSwapchain(GraphicsBackend.OpenGLES);
     }
 
 }
@@ -156,7 +139,10 @@ public abstract class GraphicsDeviceTestBase<T> : IDisposable where T : Graphics
         GD.WaitForIdle();
         _factory.DisposeCollector.DisposeAll();
         GD.Dispose();
-        _window?.Close();
+        if (_window != null)
+        {
+            MainThread.Invoke(_window.Close);
+        }
     }
 }
 


### PR DESCRIPTION
macOS only allows windows to be created and destroyed on the first thread of the process, and xUnit runs tests on pool threads. Any windowed test killed the whole run with `NSInternalInconsistencyException`. The test entry point now keeps the process main thread pumping a small work queue (`MainThread`) while the xUnit console runner runs on a secondary thread.

`dotnet test` still crashes on macOS because VSTest's testhost owns the main thread. That needs the xUnit v3 migration, which comes separately.