### PR TITLE
[Vulkan] Synchronize compute shader writes before later reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ In addition to SemVer defaults, an "Internal" section is used to denote changes 
 
 - [SDL2] Window creation failures now report the actual SDL error instead of always saying "Invalid window".
 - [SDL2] A failed window creation no longer hangs the `Sdl2Window` constructor when `threadedProcessing` is enabled.
+- [Vulkan] Fixed stale reads when draws, dispatches, or buffer copies consume compute shader output in the same command list.
 
 ### Internal
 

--- a/src/NeoVeldrid/Vk/VkCommandList.cs
+++ b/src/NeoVeldrid/Vk/VkCommandList.cs
@@ -42,6 +42,7 @@ internal unsafe class VkCommandList : CommandList
     private VkPipeline _currentComputePipeline;
     private BoundResourceSetInfo[] _currentComputeResourceSets = Array.Empty<BoundResourceSetInfo>();
     private bool[] _computeResourceSetsChanged;
+    private bool _computeWritesPending;
     private string _name;
 
     private readonly object _commandBufferListLock = new object();
@@ -180,6 +181,7 @@ internal unsafe class VkCommandList : CommandList
 
         _currentComputePipeline = null;
         ClearSets(_currentComputeResourceSets);
+        _computeWritesPending = false;
     }
 
     private protected override void ClearColorTargetCore(uint index, RgbaFloat clearColor)
@@ -285,6 +287,11 @@ internal unsafe class VkCommandList : CommandList
 
     private void PreDrawCommand()
     {
+        FlushComputeWrites(
+            PipelineStageFlags.AllGraphicsBit,
+            AccessFlags.IndirectCommandReadBit | AccessFlags.IndexReadBit |
+            AccessFlags.VertexAttributeReadBit | AccessFlags.UniformReadBit | AccessFlags.ShaderReadBit);
+
         TransitionImages(_preDrawSampledImages, ImageLayout.ShaderReadOnlyOptimal);
         _preDrawSampledImages.Clear();
 
@@ -375,11 +382,16 @@ internal unsafe class VkCommandList : CommandList
         PreDispatchCommand();
 
         _gd.Vk.CmdDispatch(_cb, groupCountX, groupCountY, groupCountZ);
+        _computeWritesPending = true;
     }
 
     private void PreDispatchCommand()
     {
         EnsureNoRenderPass();
+
+        FlushComputeWrites(
+            PipelineStageFlags.DrawIndirectBit | PipelineStageFlags.ComputeShaderBit,
+            AccessFlags.IndirectCommandReadBit | AccessFlags.UniformReadBit | AccessFlags.ShaderReadBit);
 
         for (uint currentSlot = 0; currentSlot < _currentComputePipeline.ResourceSetCount; currentSlot++)
         {
@@ -413,6 +425,33 @@ internal unsafe class VkCommandList : CommandList
         VkBuffer vkBuffer = Util.AssertSubtype<DeviceBuffer, VkBuffer>(indirectBuffer);
         _currentStagingInfo.Resources.Add(vkBuffer.RefCount);
         _gd.Vk.CmdDispatchIndirect(_cb, vkBuffer.DeviceBuffer, offset);
+        _computeWritesPending = true;
+    }
+
+    private void FlushComputeWrites(PipelineStageFlags dstStages, AccessFlags dstAccess)
+    {
+        if (!_computeWritesPending)
+        {
+            return;
+        }
+
+        _computeWritesPending = false;
+        Debug.Assert(_activeRenderPass.Handle == default);
+
+        MemoryBarrier barrier = new MemoryBarrier
+        {
+            SType = StructureType.MemoryBarrier,
+            SrcAccessMask = AccessFlags.ShaderWriteBit,
+            DstAccessMask = dstAccess
+        };
+        _gd.Vk.CmdPipelineBarrier(
+            _cb,
+            PipelineStageFlags.ComputeShaderBit,
+            dstStages,
+            0,
+            1, in barrier,
+            0, null,
+            0, null);
     }
 
     protected override void ResolveTextureCore(Texture source, Texture destination)
@@ -757,6 +796,10 @@ internal unsafe class VkCommandList : CommandList
         uint sizeInBytes)
     {
         EnsureNoRenderPass();
+
+        FlushComputeWrites(
+            PipelineStageFlags.TransferBit,
+            AccessFlags.TransferReadBit | AccessFlags.TransferWriteBit);
 
         VkBuffer srcVkBuffer = Util.AssertSubtype<DeviceBuffer, VkBuffer>(source);
         _currentStagingInfo.Resources.Add(srcVkBuffer.RefCount);

--- a/src/NeoVeldrid/Vk/VulkanUtil.cs
+++ b/src/NeoVeldrid/Vk/VulkanUtil.cs
@@ -177,7 +177,7 @@ internal unsafe static class VulkanUtil
         else if (oldLayout == ImageLayout.Preinitialized && newLayout == ImageLayout.General)
         {
             barrier.SrcAccessMask = AccessFlags.None;
-            barrier.DstAccessMask = AccessFlags.ShaderReadBit;
+            barrier.DstAccessMask = AccessFlags.ShaderReadBit | AccessFlags.ShaderWriteBit;
             srcStageFlags = PipelineStageFlags.TopOfPipeBit;
             dstStageFlags = PipelineStageFlags.ComputeShaderBit;
         }
@@ -190,9 +190,9 @@ internal unsafe static class VulkanUtil
         }
         else if (oldLayout == ImageLayout.General && newLayout == ImageLayout.ShaderReadOnlyOptimal)
         {
-            barrier.SrcAccessMask = AccessFlags.TransferReadBit;
+            barrier.SrcAccessMask = AccessFlags.ShaderWriteBit;
             barrier.DstAccessMask = AccessFlags.ShaderReadBit;
-            srcStageFlags = PipelineStageFlags.TransferBit;
+            srcStageFlags = PipelineStageFlags.ComputeShaderBit;
             dstStageFlags = PipelineStageFlags.FragmentShaderBit;
         }
         else if (oldLayout == ImageLayout.ShaderReadOnlyOptimal && newLayout == ImageLayout.General)

--- a/tests/NeoVeldrid.Tests/ComputeTests.cs
+++ b/tests/NeoVeldrid.Tests/ComputeTests.cs
@@ -196,6 +196,8 @@ void main()
         DeviceBuffer paramsBuffer = RF.CreateBuffer(new BufferDescription((uint)Unsafe.SizeOf<BasicComputeTestParams>(), BufferUsage.UniformBuffer));
         DeviceBuffer sourceBuffer = RF.CreateBuffer(new BufferDescription(width * height * 4, BufferUsage.StructuredBufferReadWrite, 4));
         DeviceBuffer destinationBuffer = RF.CreateBuffer(new BufferDescription(width * height * 4, BufferUsage.StructuredBufferReadWrite, 4));
+        DeviceBuffer sourceReadback = RF.CreateBuffer(new BufferDescription(sourceBuffer.SizeInBytes, BufferUsage.Staging));
+        DeviceBuffer destinationReadback = RF.CreateBuffer(new BufferDescription(destinationBuffer.SizeInBytes, BufferUsage.Staging));
 
         GD.UpdateBuffer(paramsBuffer, 0, new BasicComputeTestParams { Width = width, Height = height });
 
@@ -220,12 +222,12 @@ void main()
         cl.SetPipeline(pipeline);
         cl.SetComputeResourceSet(0, rs);
         cl.Dispatch(width / 16, width / 16, 1);
+        // Keep the copies in this command list to cover compute-to-transfer synchronization.
+        cl.CopyBuffer(sourceBuffer, 0, sourceReadback, 0, sourceBuffer.SizeInBytes);
+        cl.CopyBuffer(destinationBuffer, 0, destinationReadback, 0, destinationBuffer.SizeInBytes);
         cl.End();
         GD.SubmitCommands(cl);
         GD.WaitForIdle();
-
-        DeviceBuffer sourceReadback = GetReadback(sourceBuffer);
-        DeviceBuffer destinationReadback = GetReadback(destinationBuffer);
 
         MappedResourceView<float> sourceReadView = GD.Map<float>(sourceReadback, MapMode.Read);
         MappedResourceView<float> destinationReadView = GD.Map<float>(destinationReadback, MapMode.Read);


### PR DESCRIPTION
Compute shader writes were not made visible before later commands in the same command list. The storage-image transition described its source as a transfer read, while storage buffers had no memory barrier, so MoltenVK could expose stale data.

The image access masks now describe compute writes, and a deferred memory barrier runs before the next draw, dispatch, or buffer copy. `BasicCompute` now performs its readback copies in the compute command list so the compute-to-transfer path stays covered.