### PR TITLE
[Vulkan] Remove legacy MoltenVK surface path

### DIFF
--- a/src/NeoVeldrid/Vk/CommonStrings.cs
+++ b/src/NeoVeldrid/Vk/CommonStrings.cs
@@ -8,7 +8,6 @@ internal static class CommonStrings
     public static FixedUtf8String VK_KHR_XLIB_SURFACE_EXTENSION_NAME { get; } = "VK_KHR_xlib_surface";
     public static FixedUtf8String VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME { get; } = "VK_KHR_wayland_surface";
     public static FixedUtf8String VK_KHR_SWAPCHAIN_EXTENSION_NAME { get; } = "VK_KHR_swapchain";
-    public static FixedUtf8String VK_MVK_MACOS_SURFACE_EXTENSION_NAME { get; } = "VK_MVK_macos_surface";
     public static FixedUtf8String VK_EXT_METAL_SURFACE_EXTENSION_NAME { get; } = "VK_EXT_metal_surface";
     public static FixedUtf8String VK_EXT_DEBUG_REPORT_EXTENSION_NAME { get; } = "VK_EXT_debug_report";
     public static FixedUtf8String VK_EXT_DEBUG_MARKER_EXTENSION_NAME { get; } = "VK_EXT_debug_marker";

--- a/src/NeoVeldrid/Vk/VkGraphicsDevice.cs
+++ b/src/NeoVeldrid/Vk/VkGraphicsDevice.cs
@@ -535,13 +535,6 @@ internal unsafe class VkGraphicsDevice : GraphicsDevice
             {
                 _surfaceExtensions.Add(CommonStrings.VK_EXT_METAL_SURFACE_EXTENSION_NAME);
             }
-            else // Legacy MoltenVK extensions
-            {
-                if (availableInstanceExtensions.Contains(CommonStrings.VK_MVK_MACOS_SURFACE_EXTENSION_NAME))
-                {
-                    _surfaceExtensions.Add(CommonStrings.VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
-                }
-            }
         }
 
         foreach (var ext in _surfaceExtensions)
@@ -1504,7 +1497,7 @@ internal unsafe class VkGraphicsDevice : GraphicsDevice
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            return instanceExtensions.Contains(CommonStrings.VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
+            return instanceExtensions.Contains(CommonStrings.VK_EXT_METAL_SURFACE_EXTENSION_NAME);
         }
 
         return false;
@@ -1657,13 +1650,6 @@ internal unsafe delegate void vkGetBufferMemoryRequirements2_t(Device device, Bu
 internal unsafe delegate void vkGetImageMemoryRequirements2_t(Device device, ImageMemoryRequirementsInfo2KHR* pInfo, MemoryRequirements2KHR* pMemoryRequirements);
 
 internal unsafe delegate void vkGetPhysicalDeviceProperties2_t(PhysicalDevice physicalDevice, void* properties);
-
-// VK_MVK_macos_surface (legacy, no Silk.NET extension class available)
-internal unsafe delegate Result vkCreateMacOSSurfaceMVK_t(
-    Instance instance,
-    MacOSSurfaceCreateInfoMVK* pCreateInfo,
-    AllocationCallbacks* pAllocator,
-    SurfaceKHR* pSurface);
 
 internal unsafe struct VkPhysicalDeviceDriverProperties
 {

--- a/src/NeoVeldrid/Vk/VkSurfaceUtil.cs
+++ b/src/NeoVeldrid/Vk/VkSurfaceUtil.cs
@@ -35,25 +35,17 @@ internal static unsafe partial class VkSurfaceUtil
                 }
                 return CreateWin32(gd, instance, win32Source);
             case NSWindowSwapchainSource nsWindowSource:
-            {
-                bool hasMetalExtension = gd.HasSurfaceExtension(CommonStrings.VK_EXT_METAL_SURFACE_EXTENSION_NAME);
-                if (hasMetalExtension || gd.HasSurfaceExtension(CommonStrings.VK_MVK_MACOS_SURFACE_EXTENSION_NAME))
+                if (!gd.HasSurfaceExtension(CommonStrings.VK_EXT_METAL_SURFACE_EXTENSION_NAME))
                 {
-                    return CreateNSWindowSurface(gd, instance, nsWindowSource, hasMetalExtension);
+                    throw new NeoVeldridException($"The required instance extension was not available: {CommonStrings.VK_EXT_METAL_SURFACE_EXTENSION_NAME}");
                 }
-                throw new NeoVeldridException($"Neither macOS surface extension was available: " +
-                    $"{CommonStrings.VK_MVK_MACOS_SURFACE_EXTENSION_NAME}, {CommonStrings.VK_EXT_METAL_SURFACE_EXTENSION_NAME}");
-            }
+                return CreateNSWindowSurface(gd, instance, nsWindowSource);
             case NSViewSwapchainSource nsViewSource:
-            {
-                bool hasMetalExtension = gd.HasSurfaceExtension(CommonStrings.VK_EXT_METAL_SURFACE_EXTENSION_NAME);
-                if (hasMetalExtension || gd.HasSurfaceExtension(CommonStrings.VK_MVK_MACOS_SURFACE_EXTENSION_NAME))
+                if (!gd.HasSurfaceExtension(CommonStrings.VK_EXT_METAL_SURFACE_EXTENSION_NAME))
                 {
-                    return CreateNSViewSurface(gd, instance, nsViewSource, hasMetalExtension);
+                    throw new NeoVeldridException($"The required instance extension was not available: {CommonStrings.VK_EXT_METAL_SURFACE_EXTENSION_NAME}");
                 }
-                throw new NeoVeldridException($"Neither macOS surface extension was available: " +
-                    $"{CommonStrings.VK_MVK_MACOS_SURFACE_EXTENSION_NAME}, {CommonStrings.VK_EXT_METAL_SURFACE_EXTENSION_NAME}");
-            }
+                return CreateNSViewSurface(gd, instance, nsViewSource);
             default:
                 throw new NeoVeldridException($"The provided SwapchainSource cannot be used to create a Vulkan surface.");
         }
@@ -119,54 +111,30 @@ internal static unsafe partial class VkSurfaceUtil
         return surface;
     }
 
-    private static unsafe SurfaceKHR CreateNSWindowSurface(VkGraphicsDevice gd, Instance instance, NSWindowSwapchainSource nsWindowSource, bool hasExtMetalSurface)
+    private static unsafe SurfaceKHR CreateNSWindowSurface(VkGraphicsDevice gd, Instance instance, NSWindowSwapchainSource nsWindowSource)
     {
         IntPtr contentView = ObjC.MsgSendIntPtr(nsWindowSource.NSWindow, ObjC.Sel("contentView"));
-        return CreateNSViewSurface(gd, instance, new NSViewSwapchainSource(contentView), hasExtMetalSurface);
+        return CreateNSViewSurface(gd, instance, new NSViewSwapchainSource(contentView));
     }
 
-    private static unsafe SurfaceKHR CreateNSViewSurface(VkGraphicsDevice gd, Instance instance, NSViewSwapchainSource nsViewSource, bool hasExtMetalSurface)
+    private static unsafe SurfaceKHR CreateNSViewSurface(VkGraphicsDevice gd, Instance instance, NSViewSwapchainSource nsViewSource)
     {
         IntPtr metalLayer = GetOrCreateMetalLayer(nsViewSource.NSView);
 
-        if (hasExtMetalSurface)
+        MetalSurfaceCreateInfoEXT surfaceCI = new MetalSurfaceCreateInfoEXT
         {
-            MetalSurfaceCreateInfoEXT surfaceCI = new MetalSurfaceCreateInfoEXT
-            {
-                SType = StructureType.MetalSurfaceCreateInfoExt,
-                PLayer = (nint*)metalLayer
-            };
+            SType = StructureType.MetalSurfaceCreateInfoExt,
+            PLayer = (nint*)metalLayer
+        };
 
-            if (!gd.Vk.TryGetInstanceExtension(instance, out ExtMetalSurface extMetalSurface))
-            {
-                throw new NeoVeldridException("VK_EXT_metal_surface extension not available.");
-            }
-
-            SurfaceKHR surface;
-            Result result = extMetalSurface.CreateMetalSurface(instance, in surfaceCI, null, out surface);
-            CheckResult(result);
-            return surface;
-        }
-        else
+        if (!gd.Vk.TryGetInstanceExtension(instance, out ExtMetalSurface extMetalSurface))
         {
-            // Legacy path: VK_MVK_macos_surface
-            MacOSSurfaceCreateInfoMVK surfaceCI = new MacOSSurfaceCreateInfoMVK
-            {
-                SType = StructureType.MacosSurfaceCreateInfoMvk,
-                PView = nsViewSource.NSView.ToPointer()
-            };
-
-            var createMacOSSurface = gd.GetInstanceProcAddr<vkCreateMacOSSurfaceMVK_t>("vkCreateMacOSSurfaceMVK");
-            if (createMacOSSurface == null)
-            {
-                throw new NeoVeldridException("vkCreateMacOSSurfaceMVK function not found.");
-            }
-
-            SurfaceKHR surface;
-            Result result = createMacOSSurface(instance, &surfaceCI, null, &surface);
-            CheckResult(result);
-            return surface;
+            throw new NeoVeldridException("VK_EXT_metal_surface extension not available.");
         }
+
+        Result result = extMetalSurface.CreateMetalSurface(instance, in surfaceCI, null, out SurfaceKHR surface);
+        CheckResult(result);
+        return surface;
     }
 
     private static IntPtr GetOrCreateMetalLayer(IntPtr nsView)


### PR DESCRIPTION
NeoVeldrid bundles MoltenVK 1.4.0, which supports `VK_EXT_metal_surface`. The `VK_MVK_macos_surface` fallback was only needed before MoltenVK 1.0.36, so normal deployments could never reach the custom legacy delegate and NSView surface path.

This removes that fallback and uses `VK_EXT_metal_surface` exclusively on macOS. It also aligns Vulkan backend detection with the extension NeoVeldrid actually enables and uses.